### PR TITLE
Fix frame not set bug

### DIFF
--- a/src/quil/applet.clj
+++ b/src/quil/applet.clj
@@ -78,7 +78,8 @@
                    (.pack))
                  (when (= mode :opengl)
                    (.setResizable f false))
-                 (.show f))))))
+                 (.show f)
+                 f)))))
 
 (def ^{:private true}
   renderer-modes {:p2d    P2D


### PR DESCRIPTION
The frame is not properly being set, this cause applet-close and other fns which try to use the frame metadata to barf.
