### PR TITLE
Fix passing a mode key to color-mode.

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -792,7 +792,7 @@
   ([r g b] (.color *applet* (float r) (float g) (float b)))
   ([r g b a] (.color *applet* (float r) (float g) (float b) (float a))))
 
-(defn ^{:private true}
+(def ^{:private true}
   color-modes {:rgb RGB
                :hsb HSB})
 


### PR DESCRIPTION
Looks like you accidentally defined `quil.core/color-modes` as a function, rather than a var, which was causing any attempts to set the color space to blow up when the function was used as a collection. Changing the `defn` to a `def` resolves the issue. (Credit goes to @lynaghk for actually spotting the errant 'n'.)
