### PR TITLE
font-available? doesn't blow up

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -921,7 +921,7 @@
   "Returns true if font (specified as a string) is available on this
   system, false otherwise"
   [font-str]
-  (if (some #{font-str} available-fonts)
+  (if (some #{font-str} (available-fonts))
     true
     false))
 


### PR DESCRIPTION
``` clojure
(font-available? "Helvetica")
```

caused

```
Don't know how to create ISeq from: quil.core$available_fonts
```

the patch makes it work
