### PR TITLE
Added decor option

### DIFF
--- a/src/quil/applet.clj
+++ b/src/quil/applet.clj
@@ -69,7 +69,9 @@
         [width height] (or (:size m) [800 600])
         close-op       JFrame/DISPOSE_ON_CLOSE
         title          (or (:title m) (str "Quil " (swap! untitled-applet-id* inc)))
-        f              (JFrame. title)]
+        f              (JFrame. title)
+        falsify        #(not (or (nil? %) (true? %)))
+        decor?         (falsify (:decor m))]
     (doto f
       (.addWindowListener  (reify WindowListener
                              (windowActivated [this e])
@@ -80,6 +82,7 @@
                              (windowIconified [this e])
                              (windowOpened [this e])
                              (windowClosed [this e])))
+      (.setUndecorated decor?)
       (.setDefaultCloseOperation close-op)
       (.setSize width height)
       (.add applet)

--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -4311,6 +4311,9 @@
   :keep-on-top    - Specify whether the window should be on top of
                     all other OS windows.
 
+  :decor          - Specify if the window should have OS frame 
+                    decorations. 
+
   :setup          - a fn to be called once when setting the sketch up.
 
   :draw           - a fn to be repeatedly called at most n times per


### PR DESCRIPTION
Here is a new option for window decor. The addition of the falsify function is to normalize the underlying logic of "if the decoration should be removed or not", to be a simple "decorated or not", with the default being true, and an explicit false needed to override the default behavior: a decorated and titled frame that can be dragged and positioned.
