### PR TITLE
create-graphics should take renderer keywords

### DIFF
--- a/src/quil/applet.clj
+++ b/src/quil/applet.clj
@@ -116,13 +116,12 @@
     :perm-frame (launch-applet-frame applet title renderer true)
     :none applet))
 
-(def ^{:private true}
-  renderer-modes {:p2d    PApplet/P2D
-                  :p3d    PApplet/P3D
-                  :java2d PApplet/JAVA2D
-                  :opengl PApplet/OPENGL
-                  :pdf    PApplet/PDF
-                  :dxf    PApplet/DXF})
+(def renderer-modes {:p2d    PApplet/P2D
+                     :p3d    PApplet/P3D
+                     :java2d PApplet/JAVA2D
+                     :opengl PApplet/OPENGL
+                     :pdf    PApplet/PDF
+                     :dxf    PApplet/DXF})
 
 (defn- applet-set-size
   ([width height] (.size *applet* (int width) (int height)))

--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -6,7 +6,7 @@
   (:require [clojure.set])
   (:use [quil.version :only [QUIL-VERSION-STR]]
         [quil.util :only [int-like? resolve-constant-key length-of-longest-key gen-padding print-definition-list]]
-        [quil.applet :only [current-applet current-state applet-stop applet-state applet-start applet-close applet defapplet applet-tl state-tl applet-safe-exit target-frame-rate-tl]]))
+        [quil.applet :only [current-applet current-state applet-stop applet-state applet-start applet-close applet defapplet applet-tl state-tl applet-safe-exit target-frame-rate-tl renderer-modes]]))
 
 (defn
   ^{:requires-bindings true
@@ -970,17 +970,17 @@
     :subcategory nil
     :added "1.0"}
   create-graphics
-  "Creates and returns a new PGraphics object of the types P2D, P3D,
-  and JAVA2D. Use this class if you need to draw into an off-screen
-  graphics buffer. It's not possible to use create-graphics with
-  the OPENGL renderer, because it doesn't allow offscreen use. The
-  PDF renderer requires the filename parameter. The DXF renderer
-  should not be used with create-graphics, it's only built for use
-  with begin-raw and end-raw.
+  "Creates and returns a new PGraphics object with a :p2d, :p3d,
+  :java2d, or :pdf renderer. Use this class if you need to draw into
+  an off-screen graphics buffer. It's not possible to use
+  create-graphics with the :opengl renderer, because it doesn't allow
+  offscreen use. The :pdf renderer requires the filename parameter.
+  The :dxf renderer should not be used with create-graphics, it's only
+  built for use with begin-raw and end-raw.
 
   It's important to call any drawing commands between begin-draw and
   end-draw statements. This is also true for any commands that affect
-  drawing, such as smooth or colorMode.
+  drawing, such as smooth or color-mode.
 
   Unlike the main drawing surface which is completely opaque, surfaces
   created with create-graphics can have transparency. This makes it
@@ -992,9 +992,15 @@
   will be opaque blocks. This will be fixed in a future release (Issue
   80)."
   ([w h renderer]
-     (.createGraphics (current-applet) (int w) (int h) renderer))
+     (let [renderer-constant (resolve-constant-key renderer renderer-modes)]
+       (.createGraphics (current-applet) (int w) (int h) renderer-constant)))
   ([w h renderer path]
-     (.createGraphics (current-applet) (int w) (int h) renderer (str path))))
+     (let [renderer-constant (resolve-constant-key renderer renderer-modes)]
+      (.createGraphics (current-applet)
+         (int w)
+         (int h)
+         renderer-constant
+         (str path)))))
 
 (defn
   ^{:requires-bindings true


### PR DESCRIPTION
I just helped someone out on IRC who was having trouble getting `create-graphics` to work, since it's not documented anywhere what the acceptable values for the renderer arg are. I ended up looking at the source of both quil and processing in order to determine that it's expecting the string value corresponding to the processing constants for the renderer. Furthermore, passing things like `:p3d` or `"p3d"` results in confusing error message suggesting that p3d needs to be imported into the sketch with "Import Library".

So, I modified create-graphics to accept the same renderer keywords that can be used in the defsketch macro.
