### PR TITLE
Fix IllegalArgumentException in mouse-button fn.

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -2331,10 +2331,10 @@
   or :center depending on which button is pressed."
   []
   (let [button-code   (.-mouseButton (current-applet))]
-    (case button-code
-      LEFT :left
-      RIGHT :right
-      CENTER :center)))
+    (condp = button-code
+      PConstants/LEFT :left
+      PConstants/RIGHT :right
+      PConstants/CENTER :center)))
 
 (defn
   ^{:requires-bindings true


### PR DESCRIPTION
I changed it to use condp, rather than case, since we need the value of the PConstants. I'm not sure what the motivation to use case was (constant-time dispatch? There's only three possible values, and I don't think mouse-button is going to be the bottleneck in anybody's sketch ;-) ).
