### PR TITLE
Fixed bug in bezier-vertex with arity 6

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -1,4 +1,4 @@
-(ns
+﻿(ns
     ^{:doc "Wrappers and extensions around the core Processing.org API."
       :author "Roland Sadowski, Sam Aaron"}
     quil.core
@@ -555,7 +555,7 @@
   begin-shape."
   ([cx1 cy1 cx2 cy2 x y]
      (.bezierVertex (current-surface)
-                    (float cx1) (float cx1)
+                    (float cx1) (float cy1)
                     (float cx2) (float cy2)
                     (float x) (float y)))
   ([cx1 cy1 cz1 cx2 cy2 cz2 x y z]


### PR DESCRIPTION
I hope I did this correctly and followed the proper protocols; this is the first time that I've ever attempted to contribute to anything here on github. I followed the steps listed here: http://jasonlewis.me/blog/2012/06/how-to-contributing-to-a-github-project. I could not find a develop branch for the quil project so I selected the master instead; I hope that wasn't stupid. 

Anyway, while working on my latest drawing I encountered a bug in bezier-vertex. The fix is nothing extraordinary at all but the bug kept me stumped for a while.

Please let me know what further I can/must do.

Best,

dan kefford

Signed-off-by: dan kefford dan_kefford@hotmail.com
