### PR TITLE
Remove BOM from core.clj

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -1,4 +1,4 @@
-﻿(ns
+(ns
     ^{:doc "Wrappers and extensions around the core Processing.org API."
       :author "Roland Sadowski, Sam Aaron"}
     quil.core


### PR DESCRIPTION
See https://github.com/quil/quil/issues/44 
I had an error when played with quil sources in intelliJ. Error gone after I deleted BOM.
