### PR TITLE
#51 if size is a var, lookup the value

### DIFF
--- a/src/quil/applet.clj
+++ b/src/quil/applet.clj
@@ -5,7 +5,7 @@
   (:import (processing.core PApplet)
            (javax.swing JFrame)
            (java.awt.event WindowListener))
-  (:use [quil.util :only [resolve-constant-key]]
+  (:use [quil.util :only [resolve-constant-key var-value]]
         [clojure.stacktrace :only [print-cause-trace]])
   (:require [clojure.string :as string]))
 
@@ -83,7 +83,7 @@
   (let [truthify       #(not (or (nil? %) (false? %)))
         keep-on-top?   (truthify keep-on-top?)
         m              (.meta applet)
-        [width height] (or (:size m) [800 600])
+        [width height] (or (var-value (:size m)) [800 600])
         close-op       JFrame/DISPOSE_ON_CLOSE
         f              (JFrame. title)
         falsify        #(not (or (nil? %) (true? %)))
@@ -140,7 +140,7 @@
   "Checks that the size vector is exactly two elements. If not, throws
   an exception, otherwise returns the size vector unmodified."
   [size]
-  (when-not (= 2 (count size))
+  (when-not (= 2 (count (var-value size)))
     (throw (IllegalArgumentException. (str "Invalid size vector:" size ". Was expecting only 2 elements: [x-size y-size]. To specify renderer, use :renderer key."))))
   size)
 

--- a/src/quil/util.clj
+++ b/src/quil/util.clj
@@ -51,3 +51,7 @@
                   pad (gen-padding diff)]
               (println k pad "- " v)))
           definitions))))
+
+(defmacro var-value [v]
+  `(let [vv# ~v]
+     (if (var? vv#) (var-get vv#) vv#)))


### PR DESCRIPTION
I think this could resolve issue #51, allowing size to be a var.  As far as I can tell, each time you need to access size you need to see if it's a var and if it is use var-get to obtain its value.  I saw notes in defapplet about wanting to be able to get the current value so it can be updated and tried to follow that.

I ran each of the examples to test it (with the exception of the opengl examples which I could not run, I don't have opengl set up for the jvm).

Does this work?
