### PR TITLE
(width) and (height) shouldn't be used in setup.

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -1709,7 +1709,8 @@
     :added "1.0"}
   height
   "Height of the display window. The value of height is zero until
-  size is called."
+  size is called.  Should not be called during setup because result may be incosistent: 
+  https://github.com/quil/quil/issues/50"
   []
   (.getHeight (current-applet)))
 
@@ -4109,7 +4110,8 @@
     :added "1.0"}
   width
   "Width of the display window. The value of width is zero until size is
-  called."
+  called. Should not be called during setup because result may be incosistent: 
+  https://github.com/quil/quil/issues/50"
   []
   (.getWidth (current-applet)))
 


### PR DESCRIPTION
Update docs for these functions. Issue #50.
