### PR TITLE
Don't block current thread until window size is set.

### DIFF
--- a/src/quil/applet.clj
+++ b/src/quil/applet.clj
@@ -127,23 +127,15 @@
                   :pdf    PApplet/PDF
                   :dxf    PApplet/DXF})
 
-(defn- wait-event-dispatch-thread
-  "Blocks current thread until all events in AWT event dispatch thread are processed."
-  []
-  (javax.swing.SwingUtilities/invokeAndWait (fn [])))
-
 (defn- applet-set-size
   ([width height]
-     (.size (current-applet) (int width) (int height))
-     (wait-event-dispatch-thread))
+     (.size (current-applet) (int width) (int height)))
   ([width height renderer]
      (let [renderer (resolve-constant-key renderer renderer-modes)]
-       (.size (current-applet) (int width) (int height) renderer))
-     (wait-event-dispatch-thread))
-    ([width height renderer path]
+       (.size (current-applet) (int width) (int height) renderer)))
+  ([width height renderer path]
      (let [renderer (resolve-constant-key renderer renderer-modes)]
-       (.size (current-applet) (int width) (int height) renderer path))
-     (wait-event-dispatch-thread)))
+       (.size (current-applet) (int width) (int height) renderer path))))
 
 (defn- validate-size!
   "Checks that the size vector is exactly two elements. If not, throws


### PR DESCRIPTION
Revert #65. See comments in #65. I don't know how to fix it because I couldn't reproduce. I suggest to postpone this bug until work on quil 2.0 is started. May be in 2.0 there won't be such issue.  
