### PR TITLE
Bugfix for bezier-vertex arity 6

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -555,7 +555,7 @@
   begin-shape."
   ([cx1 cy1 cx2 cy2 x y]
      (.bezierVertex (current-surface)
-                    (float cx1) (float cx1)
+                    (float cx1) (float cy1)
                     (float cx2) (float cy2)
                     (float x) (float y)))
   ([cx1 cy1 cz1 cx2 cy2 cz2 x y z]


### PR DESCRIPTION
This bug was previously fixed by commit d0312f0f and was re-introduced by 2e0af0e7.

The previous bugfix came from the pull request https://github.com/quil/quil/pull/40 from quephird.
