### PR TITLE
More idiomatic fill and stroke? with-fill, with-stroke (and optionally current-fill, current-stroke)

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -4561,8 +4561,8 @@
    The code outside of with-stroke form will have the previous stroke color set.
 
    The stroke color has to be in a vector!
-   Example: (with-fill [255] ...)
-            (with-fill [10 80 98] ...)"
+   Example: (with-stroke [255] ...)
+            (with-stroke [10 80 98] ...)"
   [stroke-args & body]
   `(let [old-stroke# (current-stroke)]
      (apply stroke ~stroke-args)


### PR DESCRIPTION
I see there's already with-translation, with-rotation, with-graphics.
It seems to me it would be helpful to also have with-fill and with-stroke.

Consider this example:

``` clojure
(fill 255) ; global white fill

(rect 30 30 60 60) ; white rect

(with-fill [255 0 0]
  (rect 60 60 90 90)
  (rect 90 90 120 120)) ; two red rects

(rect 120 120 150 150) ; white rect again
```

![screen shot 2013-08-15 at 12 31 49](https://f.cloud.github.com/assets/149425/968213/5c2ee396-0598-11e3-85ca-ede4bafb46ac.png)

Also, for the user of the library there's currently no equivalent of g.fillColor and g.strokeColor. What about (current-fill) and (current-stroke) pulling them out with the (private) `(current-surface)`?
