### PR TITLE
More idiomatic fill and stroke - fns {with,current}-{fill,stroke}

### DIFF
--- a/src/quil/core.clj
+++ b/src/quil/core.clj
@@ -1095,6 +1095,26 @@
   [filename]
   (.createOutput (current-applet) (str filename)))
 
+(defn
+  ^{:requires-bindings false
+    :processing-name nil
+    :category "Color"
+    :subcategory "Creating & Reading"}
+  current-fill
+  "Return the current fill color."
+  []
+  (.fillColor (current-surface)))
+
+(defn
+  ^{:requires-bindings false
+    :processing-name nil
+    :category "Color"
+    :subcategory "Creating & Reading"}
+  current-stroke
+  "Return the current stroke color."
+  []
+  (.strokeColor (current-surface)))
+
 (def ^{:private true}
   cursor-modes {:arrow PConstants/ARROW
                 :cross PConstants/CROSS
@@ -4112,6 +4132,42 @@
   called."
   []
   (.getWidth (current-applet)))
+
+(defmacro
+  ^{:requires-bindings true
+    :processing-name nil
+    :category "Color"
+    :subcategory "Utility Macros"}
+  with-fill
+  "Temporarily set the fill color for the body of this macro.
+   The code outside of with-fill form will have the previous fill color set.
+
+   The fill color has to be in a vector!
+   Example: (with-fill [255] ...)
+            (with-fill [10 80 98] ...)"
+  [fill-args & body]
+  `(let [old-fill# (current-fill)]
+     (apply fill ~fill-args)
+     ~@body
+     (fill old-fill#)))
+
+(defmacro
+  ^{:requires-bindings true
+    :processing-name nil
+    :category "Color"
+    :subcategory "Utility Macros"}
+  with-stroke
+  "Temporarily set the stroke color for the body of this macro.
+   The code outside of with-stroke form will have the previous stroke color set.
+
+   The stroke color has to be in a vector!
+   Example: (with-stroke [255] ...)
+            (with-stroke [10 80 98] ...)"
+  [stroke-args & body]
+  `(let [old-stroke# (current-stroke)]
+     (apply stroke ~stroke-args)
+     ~@body
+     (stroke old-stroke#)))
 
 (defmacro
   ^{:requires-bindings true


### PR DESCRIPTION
Continuing from pull request #74.

As for metadata - I don't know what `:requires-bindings` is for, so I kind of guessed. You might want to check that.

I created subcategory `Utility Macros` inside `Colors` category, seeing how `Transform` uses that for `with-translation`.

``` clojure
(fill 255) ; global white fill

(rect 30 30 60 60) ; white rect

(with-fill [255 0 0]
  (rect 60 60 90 90)
  (rect 90 90 120 120)) ; two red rects

(rect 120 120 150 150) ; white rect again
```

![screen shot 2013-08-15 at 12 31 49](https://f.cloud.github.com/assets/149425/968213/5c2ee396-0598-11e3-85ca-ede4bafb46ac.png)
