### PR TITLE
Rename quil.middleware.* namespaces to quil.middlewares.* namespaces.

### DIFF
--- a/src/quil/applet.clj
+++ b/src/quil/applet.clj
@@ -5,8 +5,8 @@
            [java.awt Dimension]
            [java.awt.event WindowListener])
   (:require [quil.util :refer [resolve-constant-key no-fn absolute-path]]
-            [quil.middleware.deprecated-options :refer [deprecated-options]]
-            [quil.middleware.safe-fns :refer [safe-fns]]
+            [quil.middlewares.deprecated-options :refer [deprecated-options]]
+            [quil.middlewares.safe-fns :refer [safe-fns]]
             [clojure.string :as string]))
 
 (defonce untitled-applet-id* (atom 0))

--- a/src/quil/middleware.clj
+++ b/src/quil/middleware.clj
@@ -1,6 +1,6 @@
 (ns ^{:doc "Quil middleware."}
   quil.middleware
-  (:require [quil.middleware.fun-mode :as fun-mode]))
+  (:require [quil.middlewares.fun-mode :as fun-mode]))
 
 (defn fun-mode
   "Introduces function mode. Adds 'update' function which takes current

--- a/src/quil/middlewares/deprecated_options.clj
+++ b/src/quil/middlewares/deprecated_options.clj
@@ -1,4 +1,4 @@
-(ns quil.middleware.deprecated-options)
+(ns quil.middlewares.deprecated-options)
 
 (def ^:private deprecated
   {:decor ["2.0" "Try :features [:present] for similar effect"]

--- a/src/quil/middlewares/fun_mode.clj
+++ b/src/quil/middlewares/fun_mode.clj
@@ -1,4 +1,4 @@
-(ns quil.middleware.fun-mode
+(ns quil.middlewares.fun-mode
   (:require [quil.core :as q]))
 
 (defn- wrap-setup [options]

--- a/src/quil/middlewares/safe_fns.clj
+++ b/src/quil/middlewares/safe_fns.clj
@@ -1,4 +1,4 @@
-(ns quil.middleware.safe-fns
+(ns quil.middlewares.safe-fns
   (:require [clojure.stacktrace :refer [print-cause-trace]]))
 
 

--- a/test/manual.clj
+++ b/test/manual.clj
@@ -1,7 +1,7 @@
 (ns ^:manual
   manual
   (:require [quil.core :refer :all]
-            [quil.middleware.fun-mode :as fm]
+            [quil.middlewares.fun-mode :as fm]
             [clojure.test :refer [deftest]]))
 
 (defn draw-text-fn [& txt]

--- a/test/quil/middlewares/safe_fns_test.clj
+++ b/test/quil/middlewares/safe_fns_test.clj
@@ -1,6 +1,6 @@
-(ns quil.middleware.safe-fns-test
+(ns quil.middlewares.safe-fns-test
   (:require [clojure.test :refer :all]
-            [quil.middleware.safe-fns :refer [safe-fns]]))
+            [quil.middlewares.safe-fns :refer [safe-fns]]))
 
 (defn throw-exc []
   (throw (ex-info "Hey ho" {})))


### PR DESCRIPTION
Necessary to resolve the conflict in ClojureScript with namespaces names and function names.
For example:

If we have `quil.middleware` ns with `quil.middleware.fun-mode` function and `quil.middleware.fun-mode` ns that it translated to next js code:

`quil.middleware.fun_mode = (function(...){...})` and
`quil.middleware.fun_mode.some_fun_mode_fun = ...`

and leads to undifined call errors.
