### PR TITLE
Remove outdated note in docstring for create-graphics

### DIFF
--- a/src/cljx/quil/core.cljx
+++ b/src/cljx/quil/core.cljx
@@ -1189,9 +1189,7 @@
   created with create-graphics can have transparency. This makes it
   possible to draw into a graphics and maintain the alpha channel. By
   using save to write a PNG or TGA file, the transparency of the
-  graphics object will be honored. Note that transparency levels are
-  binary: pixels are either complete opaque or transparent. This means
-  that text characters will be opaque blocks."
+  graphics object will be honored."
   #+clj
   ([w h]
      (.createGraphics (current-applet) (int w) (int h)))


### PR DESCRIPTION
The docstring states, incorrectly, that transparency levels saved to PNG/TGA files will be binary. Thankfully, this is not the case. See here:

http://processing.org/discourse/beta/num_1271238026.html

I also tested saving transparency to a PNG with 2.2.0, and it does save partial transparency.
