### PR TITLE
Fix set-pixel and get-pixel functions

### DIFF
--- a/src/cljx/quil/core.cljx
+++ b/src/cljx/quil/core.cljx
@@ -150,24 +150,6 @@
 #+cljs
 (defn
   ^{:require-bindings true
-    :category "Image"
-    :subcategory "Pixels"
-    :added "1.0"}
-  load-pixels
-  "Loads the pixel data for the display window (or an image) into the pixels[] array.
-  This function must always be called before reading from or writing to pixels[].
-
-  Certain renderers may or may not seem to require loadPixels() or updatePixels().
-  However, the rule is that any time you want to manipulate the pixels[] array,
-  you must first call loadPixels(), and after changes have been made, call updatePixels().
-  Even if the renderer may not seem to use this function in the current Processing release,
-  this will always be subject to change."
-  ([] (.loadPixels (current-graphics)))
-  ([gr] (.loadPixels gr)))
-
-#+cljs
-(defn
-  ^{:require-bindings true
     :category "Output"
     :subcategory "Text area"
     :added "1.0"}
@@ -2801,9 +2783,18 @@
 
   Only works with P2D and P3D renderer if used without arguments."
   ([] (pixels (current-graphics)))
+
+  #+clj
   ([^PImage img]
-    (.loadPixels img)
-    (.-pixels img)))
+   (.loadPixels img)
+   (.-pixels img))
+
+  #+cljs
+  ([proc]
+   (.loadPixels proc)
+   (let [pix-array (.toArray (.-pixels proc))]
+     (set! (.-stored-pix-array proc) pix-array)
+     pix-array)))
 
 (defn
   ^{:requires-bindings true
@@ -4383,7 +4374,17 @@
   renderer may not seem to use this function in the current Processing
   release, this will always be subject to change."
   ([] (update-pixels (current-graphics)))
-  ([^PImage img] (.updatePixels img)))
+  #+clj ([^PImage img] (.updatePixels img))
+
+  #+cljs
+  ([proc]
+   (let [pix-array (.-stored-pix-array proc)]
+     (if pix-array
+       (do
+         (.set (.-pixels proc) pix-array)
+         (set! (.-stored-pix-array proc) nil)
+         (.updatePixels proc))
+       (.updatePixels proc)))))
 
 (defn
   ^{:requires-bindings true

--- a/test/clj/test_server.clj
+++ b/test/clj/test_server.clj
@@ -30,6 +30,7 @@
     (gen-test-canvas "fun-mode")
     (gen-test-canvas "get-pixel")
     (gen-test-canvas "set-pixel")
+    (gen-test-canvas "pixels-update-pixels")
 
     [:div.cbox
      [:p "extern-control test"]

--- a/test/cljs/snippets/manual.cljs
+++ b/test/cljs/snippets/manual.cljs
@@ -103,8 +103,6 @@
             (q/with-graphics gr
               (q/background 255))
 
-            (q/load-pixels gr)
-
             (doseq [i (range 30)
                     j (range 30)]
               (q/set-pixel gr i j (q/color (* 7 i) (* 7 j) 0)))
@@ -114,3 +112,19 @@
             (doseq [i (range 30)
                     j (range 30)]
               (q/set-pixel (+ 40 i) (+ 40 j) (q/color 0 (* 7 i) (* 7 j)))))))
+
+
+(q/defsketch pixels-update-pixels
+  :size [500 500]
+  :draw (fn []
+          (q/background 55)
+          (let [gr (q/create-graphics 100 100)]
+            (q/with-graphics gr
+              (q/background 55))
+
+            (let [px (q/pixels gr)]
+              (dotimes [i 200]
+                (aset px i (q/color 255))))
+            (q/update-pixels gr)
+
+            (q/image gr 10 10))))


### PR DESCRIPTION
I think that adding support of `pixels[]` to ClojureScript version don't have a sense.
Because user must pack\unpack color to `pixels[]`:

https://github.com/processing-js/processing-js/blob/master/processing.js#L19153
https://github.com/processing-js/processing-js/blob/master/processing.js#L19136

So, in this case I think that users will use `set-pixel` and `get-pixel` for working with `pixels[]`.
Because realization of `pixels[]` in Java and JavaScript Processing is different.

P.S. Tests for `set-pixel` and `get-pixel` maked manual. Because if we run it in common canvas this is raise Security exception (canvas context dirtied by previously loaded images). 
