### PR TITLE
Refactor tally to use reductions

### DIFF
--- a/src/clj/quil/helpers/seqs.clj
+++ b/src/clj/quil/helpers/seqs.clj
@@ -118,19 +118,16 @@
         (first old)))))
 
 (defn tally
-  "Cumulative tally. Takes a sequence of numbers and returns a new
-  sequence which is a cumulative tally of the successive additions of
-  each element in the original seq.
+  "Cumulative tally. Returns a lazy sequence of the successive sums
+  of coll, starting with init plus the first element.
 
-  (take 5 (tally (range))) ;=> [0 1 3 6 10]"
-  ([s] (tally s 0))
-  ([s amount]
-     (lazy-seq
-      (let [nxt-amount (+ (first s) amount)
-            nxt-s (next s)]
-        (cons nxt-amount (if nxt-s
-                           (tally nxt-s nxt-amount)
-                           []))))))
+  (take 5 (tally (range)))   ;=> (0 1 3 6 10)
+  (take 5 (tally 3 (range))) ;=> (3 4 6 9 13)
+  (tally [])                 ;=> ()
+  (tally 100 [])             ;=> ()"
+  ([coll] (tally 0 coll))
+  ([init coll]
+     (rest (reductions + init coll))))
 
 (defn perlin-noise-seq
   "Generate a lazy infinite sequence of perlin noise values starting from


### PR DESCRIPTION
Hi.

This commit updates the `tally` function to use [`clojure.core/reductions`](https://github.com/clojure/clojure/blob/clojure-1.6.0/src/clj/clojure/core.clj#L6628) to calculate the result. The `reductions` function has been around since 1.2, so I think it should be safe to use for the Clojure versions Quil supports.

The results should be consistent with the old implementation of `tally`, but I don't think this function is tested yet so probably worth a closer review.

A few other changes:

- the order of arguments is now reversed, i.e. `(tally initial-value collection)`
- `tally` now returns an empty sequence when given an empty sequence instead of throwing a `NullPointerException`
- the docstring is tightened up and a few more examples are given

Let me know if there are any issues. Feel free to ignore if you think the change is not worth it.

Amazing project.

All the best,
O-I