### PR TITLE
Support for generating random unit vectors in 2D & 3D

### DIFF
--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -2671,6 +2671,32 @@
 
 (defn
   ^{:requires-bindings true
+    :processing-name "random2d()"
+    :category "Math"
+    :subcategory "Random"
+    :added "2.6"}
+  random-2d
+  "Returns a new 2D unit vector in a random direction" []
+  (let [theta (.random (ap/current-applet) TWO-PI)]
+    [(Math/cos theta) (Math/sin theta)]))
+
+(defn
+  ^{:requires-bindings true
+    :processing-name "random3d()"
+    :category "Math"
+    :subcategory "Random"
+    :added "2.6"}
+  random-3d
+  "Returns a new 3D unit vector in a random direction" []
+  (let [theta (.random (ap/current-applet) TWO-PI)
+        phi   (.random (ap/current-applet) (- HALF-PI) HALF-PI)
+        vx    (* (Math/cos theta) (Math/sin phi))
+        vy    (* (Math/sin theta) (Math/sin phi))
+        vz    (Math/cos phi)]
+    [vx vy vz]))
+
+(defn
+  ^{:requires-bindings true
     :processing-name "noise()"
     :category "Math"
     :subcategory "Random"

--- a/test/cljc/snippets/math/random.cljc
+++ b/test/cljc/snippets/math/random.cljc
@@ -48,12 +48,17 @@
     (< (Math/abs (- n 1.0)) 0.001)))
 
 (defsnippet random-2d {}
-    (q/background 255)
-    (q/fill 0)
-    (q/text (str "unit 2D vector? " (unit-vector? (q/random-2d))) 10 20))
+  (q/background 255)
+  (q/fill 0)
+  (q/text (str "(q/random-2d) = " (q/random-2d)) 10 20)
+  (dotimes [_ 100]
+    (when-not (unit-vector? (q/random-2d))
+        (throw (Exception. "random-2d doesn't return a unit vector")))))
 
 (defsnippet random-3d {}
   (q/background 255)
   (q/fill 0)
-  (q/text (str "unit 3D vector? " (unit-vector? (q/random-3d))) 10 20))
-
+  (q/text (str "(q/random-3d) = " (q/random-3d)) 10 20)
+  (dotimes [_ 100]
+    (when-not (unit-vector? (q/random-3d))
+        (throw (Exception. "random-3d doesn't return a unit vector")))))

--- a/test/cljc/snippets/math/random.cljc
+++ b/test/cljc/snippets/math/random.cljc
@@ -42,3 +42,14 @@
   (q/fill 0)
   (q/random-seed 42)
   (q/text (str "(q/random 42) = " (q/random 42)) 10 20))
+
+(defsnippet random-2d {}
+  (q/background 255)
+  (q/fill 0)
+  (q/text (str "(q/random-2d) = " (q/random-2d)) 10 20))
+
+(defsnippet random-3d {}
+  (q/background 255)
+  (q/fill 0)
+  (q/text (str "(q/random-3d) = " (q/random-3d)) 10 20))
+

--- a/test/cljc/snippets/math/random.cljc
+++ b/test/cljc/snippets/math/random.cljc
@@ -43,13 +43,17 @@
   (q/random-seed 42)
   (q/text (str "(q/random 42) = " (q/random 42)) 10 20))
 
+(defn- unit-vector? [v]
+  (let [n (->> v (map q/sq) (apply +))]
+    (< (Math/abs (- n 1.0)) 0.001)))
+
 (defsnippet random-2d {}
-  (q/background 255)
-  (q/fill 0)
-  (q/text (str "(q/random-2d) = " (q/random-2d)) 10 20))
+    (q/background 255)
+    (q/fill 0)
+    (q/text (str "unit 2D vector? " (unit-vector? (q/random-2d))) 10 20))
 
 (defsnippet random-3d {}
   (q/background 255)
   (q/fill 0)
-  (q/text (str "(q/random-3d) = " (q/random-3d)) 10 20))
+  (q/text (str "unit 3D vector? " (unit-vector? (q/random-3d))) 10 20))
 


### PR DESCRIPTION
Picking up from #200, this PR adds functionality as found in Processing - [random2D](https://p5js.org/reference/#/p5.Vector/random2D) & [random3D](https://p5js.org/reference/#/p5.Vector/random3D).

@nbeloglazov, quick question - I used the `cos` and `sin` implementations from `Math` so that I don't have to write to different versions for `clj` and `cljs`. Is this fine?