### PR TITLE
Add DISABLE_ASYNC_SAVEFRAME hint option

### DIFF
--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -51,7 +51,8 @@
  color-modes (:rgb :hsb)
  image-formats (:rgb :argb :alpha)
  ellipse-modes (:center :radius :corner :corners)
- hint-options (:enable-depth-test :disable-depth-test
+ hint-options (:enable-async-saveframe :disable-async-saveframe
+               :enable-depth-test :disable-depth-test
                                   :enable-depth-sort :disable-depth-sort
                                   :enable-depth-mask :disable-depth-mask
                                   :enable-opengl-errors :disable-opengl-errors

--- a/test/cljc/snippets/rendering.cljc
+++ b/test/cljc/snippets/rendering.cljc
@@ -6,7 +6,9 @@
      (:use-macros [quil.snippet :only [defsnippet]])))
 
 (defsnippet hint {:renderer :p3d}
-  (let [hints [:enable-depth-test
+  (let [hints [:enable-async-saveframe
+               :disable-async-saveframe
+               :enable-depth-test
                :disable-depth-test
                :enable-depth-sort
                :disable-depth-sort


### PR DESCRIPTION
The latest documentation includes this hint option, though those docs haven't been published online yet.

See https://github.com/processing/processing-docs/commit/69fcbc307a8dff592d176ec8c2f99873d1622874.