### PR TITLE
Improved with fill,stroke

### DIFF
--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -4663,14 +4663,29 @@
   "Temporarily set the fill color for the body of this macro.
    The code outside of with-fill form will have the previous fill color set.
 
-   The fill color has to be in a vector!
-   Example: (with-fill [255] ...)
-            (with-fill [10 80 98] ...)"
-  [fill-args & body]
-  `(let [old-fill# (quil.core/current-fill)]
-     (apply quil.core/fill ~fill-args)
-     ~@body
-     (quil.core/fill old-fill#)))
+   A fill argument of nil disables the fill.
+
+   Example: (with-fill 255 ...)
+            (with-fill [10 80 98] ...)
+            (with-fill (quil.core/color 13 27 42) ...)
+            (with-fill nil ...)"
+  [fill & body]
+  `(let [fill# ~fill
+         fill-was-enabled# (.fill (quil.core/current-graphics))
+         previous-fill# (quil.core/current-fill)]
+
+     (cond (not fill#) (quil.core/no-fill)
+           (sequential? fill#) (apply quil.core/fill fill#)
+           true (quil.core/fill fill#))
+
+     ;;return the value from body, not from the if after it.
+     (let [return-val# (do ~@body)]
+
+       ;;reset the previous fill even if it was disabled; other code could call (quil.core/current-fill)
+       (quil.core/fill previous-fill#)
+       (if-not fill-was-enabled#
+         (quil.core/no-fill))
+       return-val#)))
 
 (defmacro
   ^{:requires-bindings true
@@ -4682,14 +4697,29 @@
   "Temporarily set the stroke color for the body of this macro.
    The code outside of with-stroke form will have the previous stroke color set.
 
-   The stroke color has to be in a vector!
-   Example: (with-stroke [255] ...)
-            (with-stroke [10 80 98] ...)"
-  [stroke-args & body]
-  `(let [old-stroke# (quil.core/current-stroke)]
-     (apply quil.core/stroke ~stroke-args)
-     ~@body
-     (quil.core/stroke old-stroke#)))
+   A stroke argument of nil disables the stroke.
+
+   Example: (with-stroke 255 ...)
+            (with-stroke [10 80 98] ...)
+            (with-stroke (quil.core/color 13 27 42) ...)
+            (with-stroke nil ...)"
+  [stroke & body]
+  `(let [stroke# ~stroke
+         stroke-was-enabled# (.stroke (quil.core/current-graphics))
+         previous-stroke# (quil.core/current-stroke)]
+
+     (cond (not stroke#) (quil.core/no-stroke)
+           (sequential? stroke#) (apply quil.core/stroke stroke#)
+           true (quil.core/stroke stroke#))
+
+     ;;return the value from body, not from the if after it.
+     (let [return-val# (do ~@body)]
+
+       ;;reset the previous stroke even if it was disabled; other code could call (quil.core/current-stroke)
+       (quil.core/stroke previous-stroke#)
+       (if-not stroke-was-enabled#
+         (quil.core/no-stroke))
+       return-val#)))
 
 (defmacro
   ^{:requires-bindings true

--- a/test/clj/manual.clj
+++ b/test/clj/manual.clj
@@ -154,5 +154,127 @@
               redraw-on-key
               fun-mode
               resize-sketch
+              with-stroke
+              with-fill
               on-close-and-exit-on-close]]
     (fn)))
+
+(defn with-stroke []
+  (let [lock (promise)]
+    (q/sketch
+     :size [800 500]
+     :on-close #(deliver lock true)
+     :setup q/no-loop
+     :draw (fn []
+             (q/stroke-weight 5)
+             (q/fill (q/color 0 10 10 90))
+
+             ;;no-stroke -> stroke -> no-stroke
+             (let [base-x 100]
+               (q/no-stroke)
+               (q/rect base-x 100 90 90)
+               (q/with-stroke (q/color 0 100 0)
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+             ;;no-stroke -> vector stroke -> no-stroke
+             (let [base-x 200]
+               (q/no-stroke)
+               (q/rect base-x 100 90 90)
+               (q/with-stroke [0 100 0]
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+
+             ;;stroke -> no-stroke -> stroke
+             (let [base-x 300]
+               (q/stroke (q/color 0 100 0))
+               (q/rect base-x 100 90 90)
+               (q/with-stroke nil
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+             ;;stroke -> different stroke -> original stroke
+             (let [base-x 400]
+               (q/stroke (q/color 0 100 0))
+               (q/rect base-x 100 90 90)
+               (q/with-stroke (q/color 180 100 0)
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+             ;;stroke -> different vector stroke -> original stroke
+             (let [base-x 500]
+               (q/stroke (q/color 0 100 0))
+               (q/rect base-x 100 90 90)
+               (q/with-stroke [180 100 0]
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+             ;;no-stroke -> no-stroke -> no-stroke
+             (let [base-x 600]
+               (q/no-stroke)
+               (q/rect base-x 100 90 90)
+               (q/with-stroke nil
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))))
+    @lock))
+
+(defn with-fill []
+  (let [lock (promise)]
+    (q/sketch
+     :size [800 500]
+     :on-close #(deliver lock true)
+     :setup q/no-loop
+     :draw (fn []
+             (q/stroke-weight 5)
+             (q/fill (q/color 0 10 10 90))
+
+             ;;no-fill -> fill -> no-fill
+             (let [base-x 100]
+               (q/no-fill)
+               (q/rect base-x 100 90 90)
+               (with-fill (q/color 0 100 0)
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+             ;;no-fill -> vector fill -> no-fill
+             (let [base-x 200]
+               (q/no-fill)
+               (q/rect base-x 100 90 90)
+               (with-fill [0 100 0]
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+
+             ;;fill -> no-fill -> fill
+             (let [base-x 300]
+               (q/fill (q/color 0 100 0))
+               (q/rect base-x 100 90 90)
+               (with-fill nil
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+             ;;fill -> different fill -> original fill
+             (let [base-x 400]
+               (q/fill (q/color 0 100 0))
+               (q/rect base-x 100 90 90)
+               (with-fill (q/color 180 100 0)
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+             ;;fill -> different vector fill -> original fill
+             (let [base-x 500]
+               (q/fill (q/color 0 100 0))
+               (q/rect base-x 100 90 90)
+               (with-fill [180 100 0]
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))
+
+             ;;no-fill -> no-fill -> no-fill
+             (let [base-x 600]
+               (q/no-fill)
+               (q/rect base-x 100 90 90)
+               (with-fill nil
+                 (q/rect base-x 200 90 90))
+               (q/rect base-x 300 90 90))))
+    @lock))


### PR DESCRIPTION
This PR adds functionality to `with-fill` and `with-stroke`. I had suggested this in [issue 238](https://github.com/quil/quil/issues/238), and recently felt like implementing it. Its main purpose is to allow more things to be passed to these functions:

1. `nil` disables the fill or stroke.
2. Bare numbers (e.g., `42`) use the color of grey corresponding to that number.
3. Colors from `quil.core/color` can be passed.

There are some additional improvements:

1. If the fill was disabled before `with-fill`, it will be disabled after it. Previously it would be re-enabled.
2. The macros now return the value of the last thing in the body. It should rarely matter, but it opens up some possibilities.

## Ensuring this works:

1. I tried to write some tests. I thought it shouldn't be too difficult; just use `quil.core/current-fill` to make sure the fill is what it should be. However, after I wrote some tests, with `quil.core/defsketch` inside the tests, when I ran the tests, I got "no assertions run". Is there a way to write unit tests with assertions inside a `defsketch`? Or another way to test this stuff? I don't see `defsketch` used inside tests, just in `manual.clj`. It's possible to fix, I'd like to add some tests.

2. Because I couldn't find a way to automatically test it, I added manual tests to `test/clj/manual.clj`. They graph a series of columns of rectangles. In each column, there is a rectangle before the `with-fill` (or `with-stroke`), a rectangle inside the `with-fill`, and a rectangle after it. However, I'm having trouble running the sketch. When I connect to it with Emacs (cider-jack-in), and compile the buffer, I get this error:
```
2. Unhandled clojure.lang.Compiler$CompilerException Error compiling quil/core.cljc at (7:3)
1. Caused by java.lang.RuntimeException
   No such var: q/defsketch
```

What am I doing to run this wrong? I suspect it's loading `test/cljc/quil/core.cljc` instead of `src/cljc/quil/core.cljc` (hitting the link to `quil/core.cljc` in the error message above leads me to the test `core.cljc`), but I'm not sure how to properly run this. I'd like to get it to run before suggesting this be merged, and it seems like although it's odd, the best way is to open a PR here and ask.
