### PR TITLE
change documentation to explain the input type

### DIFF
--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -1545,7 +1545,8 @@
     :subcategory "Setting"
     :added "1.0"}
   fill
-  "Sets the color used to fill shapes."
+  "Sets the color used to fill shapes. For example, if you run fill(204, 102, 0),
+  all subsequent shapes will be filled with orange.  This function casts all input as a float"
   ([gray]
    (.fill (current-graphics) (float gray))
    #?(:cljs (clear-no-fill-cljs (current-graphics))))


### PR DESCRIPTION
Relates to https://github.com/quil/quil/issues/252

I thought it would be appropriate to update the doc string to reflect the changes from yesterday as well as explain all input is cast as a float. 