### PR TITLE
Mention `:svg` renderer in `defsketch` docs

### DIFF
--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -4571,12 +4571,12 @@
                      all sketches are support fullscreen when you press F11.
 
    :renderer       - Specifies the renderer type. One of :p2d, :p3d, :java2d,
-                     :opengl, :pdf). Defaults to :java2d. :dxf renderer
+                     :opengl, :pdf, :svg). Defaults to :java2d. :dxf renderer
                      can't be used as sketch renderer. Use begin-raw method
                      instead. In clojurescript only :p2d and :p3d renderers
                      are supported.
 
-   :output-file    - Specifies an output file path. Only used in :pdf mode.
+   :output-file    - Specifies an output file path. Only used in :pdf and :svg modes.
                      Not supported in clojurescript.
 
    :title          - A string which will be displayed at the top of

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -4577,7 +4577,9 @@
                      are supported.
 
    :output-file    - Specifies an output file path. Only used in :pdf and :svg modes.
-                     Not supported in clojurescript.
+                     Not supported in clojurescript. When writing to a file, call
+                     `(q/exit)` at the end of the draw call to end the sketch and not
+                     write repeatedly to the file.
 
    :title          - A string which will be displayed at the top of
                      the sketch window. Not supported in clojurescript.


### PR DESCRIPTION
Was looking for this and only found its existence from #188 and the associated commit 14f08e6.

As an aside, it wasn't immediately obvious to me that without calling `(q/exit)` in the draw method, the file just kept re-rendering in the background as the program kept running - is it worth mentioning somewhere?

Thanks!