### PR TITLE
p5js image (part 1)

### DIFF
--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -1001,7 +1001,7 @@
     :subcategory "Pixels"
     :added "1.0"}
   copy
-  "Copies a region of pixels from the one image to another. If src-img
+  "Copies a region of pixels from one image to another. If src-img
   is not specified it defaults to current-graphics. If dest-img is not
   specified - it defaults to current-graphics. If the source
   and destination regions aren't the same size, it will automatically
@@ -1017,7 +1017,8 @@
    (copy src-img (current-graphics) [sx sy swidth sheight] [dx dy dwidth dheight]))
 
   ([^PImage src-img ^PImage dest-img [sx sy swidth sheight] [dx dy dwidth dheight]]
-   (.copy dest-img src-img (int sx) (int sy) (int swidth) (int sheight)
+   (.copy dest-img src-img
+          (int sx) (int sy) (int swidth) (int sheight)
           (int dx) (int dy) (int dwidth) (int dheight))))
 
 (defn

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -1454,7 +1454,7 @@
              corners of the ellipse's bounding box."
   [mode]
   (let [mode (u/resolve-constant-key mode ellipse-modes)]
-    (.ellipseMode (current-graphics) (int mode))))
+    (.ellipseMode (current-graphics) mode)))
 
 #?(:clj
    (defn
@@ -1626,9 +1626,9 @@
                colors specified as the level parameter. The parameter can
                be set to values between 2 and 255, but results are most
                noticeable in the lower ranges.
-  :blur      - executes a Guassian blur with the level parameter
+  :blur      - executes a Gaussian blur with the level parameter
                specifying the extent of the blurring. If no level
-               parameter is used, the blur is equivalent to Guassian
+               parameter is used, the blur is equivalent to Gaussian
                blur of radius 1.
   :opaque    - sets the alpha channel to entirely opaque. Doesn't work
                with level.
@@ -1636,11 +1636,11 @@
   :dilate    - increases the light areas.  Doesn't work with level."
   ([mode]
    (.filter (current-graphics)
-            (int (u/resolve-constant-key mode filter-modes))))
+            (u/resolve-constant-key mode filter-modes)))
 
   ([mode level]
    (let [mode (u/resolve-constant-key mode filter-modes)]
-     (.filter (current-graphics) (int mode) (float level)))))
+     (.filter (current-graphics) mode (float level)))))
 
 #?(:clj
    (defn
@@ -1966,9 +1966,9 @@
                colors specified as the level parameter. The parameter can
                be set to values between 2 and 255, but results are most
                noticeable in the lower ranges.
-  :blur      - executes a Guassian blur with the level parameter
+  :blur      - executes a Gaussian blur with the level parameter
                specifying the extent of the blurring. If no level
-               parameter is used, the blur is equivalent to Guassian
+               parameter is used, the blur is equivalent to Gaussian
                blur of radius 1.
   :opaque    - sets the alpha channel to entirely opaque. Doesn't work
                with level.
@@ -1976,10 +1976,10 @@
   :dilate    - increases the light areas.  Doesn't work with level."
   ([^PImage img mode]
    (let [mode (u/resolve-constant-key mode filter-modes)]
-     (.filter img (int mode))))
+     (.filter img mode)))
   ([^PImage img mode level]
    (let [mode (u/resolve-constant-key mode filter-modes)]
-     (.filter img (int mode) (float level)))))
+     (.filter img mode (float level)))))
 
 (defn
   ^{:requires-bindings true

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -1133,19 +1133,24 @@
     :subcategory nil
     :added "1.0"}
   create-image
-  "Creates a new PImage (the datatype for storing images). This
-  provides a fresh buffer of pixels to play with. Set the size of the
-  buffer with the width and height parameters. The format parameter
-  defines how the pixels are stored. See the PImage reference for more
-  information.
+ "Creates a new datatype for storing images (PImage for clj and
+  Image for cljs). This provides a fresh buffer of pixels to play
+  with. Set the size of the buffer with the width and height
+  parameters.
 
+  In clj the format parameter defines how the pixels are stored.
+  See the PImage reference for more information.
   Possible formats: :rgb, :argb, :alpha (grayscale alpha channel)
 
-  Prefer using create-image over initialising new PImage instances
-  directly."
-  [w h format]
-  (let [format (u/resolve-constant-key format image-formats)]
-    (.createImage (ap/current-applet) (int w) (int h) (int format))))
+  Prefer using create-image over initialising new PImage (or Image)
+  instances directly."
+  #?@(:clj
+      ([w h format]
+       (let [format (u/resolve-constant-key format image-formats)]
+         (.createImage (ap/current-applet) (int w) (int h) (int format))))
+      :cljs
+      ([w h]
+       (.createImage (ap/current-applet) (int w) (int h)))))
 
 (defn
   ^{:requires-bindings true

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -3174,14 +3174,15 @@
   #?(:cljs ([n]
             (.redraw (ap/current-applet) n))))
 
-(defn
-  ^{:requires-bindings true
-    :processing-name "requestImage()"
-    :category "Image"
-    :subcategory "Loading & Displaying"
-    :added "1.0"}
-  request-image
-  "This function load images on a separate thread so that your sketch
+#?(:clj
+   (defn
+     ^{:requires-bindings true
+       :processing-name "requestImage()"
+       :category "Image"
+       :subcategory "Loading & Displaying"
+       :added "1.0"}
+     request-image
+     "This function loads an image on a separate thread so that your sketch
   does not freeze while images load during setup. While the image is
   loading, its width and height will be 0. If an error occurs while
   loading the image, its width and height will be set to -1. You'll
@@ -3189,7 +3190,7 @@
   will be greater than 0. Asynchronous image loading (particularly
   when downloading from a server) can dramatically improve
   performance."
-  [filename] (.requestImage (ap/current-applet) (str filename)))
+     [filename] (.requestImage (ap/current-applet) (str filename))))
 
 (defn
   ^{:requires-bindings true

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -2857,16 +2857,17 @@
   #?(:clj (PApplet/pow (float num) (float exponent))
      :cljs (.pow (ap/current-applet) num exponent)))
 
-(defn
-  ^{:requires-bindings true
-    :processing-name "printCamera()"
-    :category "Lights, Camera"
-    :subcategory "Camera"
-    :added "1.0"}
-  print-camera
-  "Prints the current camera matrix to std out. Useful for debugging."
-  []
-  (.printCamera (current-graphics)))
+#?(:clj
+   (defn
+     ^{:requires-bindings true
+       :processing-name "printCamera()"
+       :category "Lights, Camera"
+       :subcategory "Camera"
+       :added "1.0"}
+     print-camera
+     "Prints the current camera matrix to std out. Useful for debugging."
+     []
+     (.printCamera (current-graphics))))
 
 (defn
   ^{:requires-bindings true
@@ -2879,17 +2880,18 @@
   []
   (.printMatrix (current-graphics)))
 
-(defn
-  ^{:requires-bindings true
-    :processing-name "printProjection()"
-    :category "Lights, Camera"
-    :subcategory "Camera"
-    :added "1.0"}
-  print-projection
-  "Prints the current projection matrix to std out. Useful for
-  debugging"
-  []
-  (.printProjection (current-graphics)))
+#?(:clj
+   (defn
+     ^{:requires-bindings true
+       :processing-name "printProjection()"
+       :category "Lights, Camera"
+       :subcategory "Camera"
+       :added "1.0"}
+     print-projection
+     "Prints the current projection matrix to std out. Useful for
+     debugging"
+     []
+     (.printProjection (current-graphics))))
 
 (defn
   ^{:requires-bindings true

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -2003,7 +2003,7 @@
   :center  - draw images centered at the given x and y position."
   [mode]
   (let [mode (u/resolve-constant-key mode image-modes)]
-    (.imageMode (current-graphics) (int mode))))
+    (.imageMode (current-graphics) mode)))
 
 (defn
   ^{:requires-bindings true

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -3515,7 +3515,7 @@
   help. (Bug 1094)"
   ([x y c] (set-pixel (current-graphics) x y c))
   ([^PImage img x y c]
-   (.set img (int x) (int y) (int c))))
+   (.set img (int x) (int y) c)))
 
 (defn
   ^{:requires-bindings true

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -1197,18 +1197,19 @@
               #?(:clj (int cursor-mode)
                  :cljs (str cursor-mode))))))
 
-(defn
-  ^{:requires-bindings true
-    :processing-name "cursor()"
-    :category "Environment"
-    :subcategory nil
-    :added "1.0"}
-  cursor-image
-  "Set the cursor to a predefined image. The horizontal and vertical
-  active spots of the cursor may be specified with hx and hy.
-  It is recommended to make the size 16x16 or 32x32 pixels."
-  ([^PImage img] (.cursor (ap/current-applet) img))
-  ([^PImage img hx hy] (.cursor (ap/current-applet) img (int hx) (int hy))))
+#?(:clj
+   (defn
+     ^{:requires-bindings true
+       :processing-name "cursor()"
+       :category "Environment"
+       :subcategory nil
+       :added "1.0"}
+     cursor-image
+     "Set the cursor to a predefined image. The horizontal and vertical
+     active spots of the cursor may be specified with hx and hy.
+     It is recommended to make the size 16x16 or 32x32 pixels."
+     ([^PImage img] (.cursor (ap/current-applet) img))
+     ([^PImage img hx hy] (.cursor (ap/current-applet) img (int hx) (int hy)))))
 
 (defn
   ^{:requires-bindings true
@@ -2751,6 +2752,17 @@
       (let [pix-array (.toArray (.-pixels img))]
         (set! (.-stored-pix-array img) pix-array)
         pix-array))))
+#?(:cljs
+   (defn
+     ^{:requires-bindings true
+       :processing-name "plane()"
+       :category "Shape"
+       :subcategory "3D Primitives"
+       :added "3.0.0"}
+     plane
+     "Draw a plane with given a width and height."
+     [width height]
+     (.plane (current-graphics) (float width) (float height))))
 
 (defn
   ^{:requires-bindings true
@@ -4169,14 +4181,15 @@
      :cljs [img])
   (.texture (current-graphics) img))
 
-(defn
-  ^{:requires-bindings true
-    :processing-name "textureMode()"
-    :category "Shape"
-    :subcategory "Vertex"
-    :added "1.0"}
-  texture-mode
-  "Sets the coordinate space for texture mapping. There are two
+#?(:clj
+   (defn
+     ^{:requires-bindings true
+       :processing-name "textureMode()"
+       :category "Shape"
+       :subcategory "Vertex"
+       :added "1.0"}
+     texture-mode
+     "Sets the coordinate space for texture mapping. There are two
   options, :image and :normal.
 
   :image refers to the actual coordinates of the image and :normal
@@ -4185,9 +4198,9 @@
   mapping the image onto the entire size of a quad would require the
   points (0,0) (0,100) (100,200) (0,200). The same mapping in
   NORMAL_SPACE is (0,0) (0,1) (1,1) (0,1)."
-  [mode]
-  (let [mode (u/resolve-constant-key mode texture-modes)]
-    (.textureMode (current-graphics) (int mode))))
+     [mode]
+     (let [mode (u/resolve-constant-key mode texture-modes)]
+       (.textureMode (current-graphics) (int mode)))))
 
 #?(:clj
    (defn

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -1119,13 +1119,14 @@
   using save to write a PNG or TGA file, the transparency of the
   graphics object will be honored."
   ([w h]
-   (.createGraphics (ap/current-applet) (int w) (int h) #?(:cljs :p2d)))
+   (.createGraphics (ap/current-applet) (int w) (int h)))
   ([w h renderer]
    (.createGraphics (ap/current-applet) (int w) (int h) (ap/resolve-renderer renderer)))
-  ([w h renderer path]
-   (.createGraphics (ap/current-applet) (int w) (int h) (ap/resolve-renderer renderer)
-                    #?(:clj (u/absolute-path path)
-                       :cljs path))))
+  #?(:clj
+     ([w h renderer path]
+      (.createGraphics (ap/current-applet) (int w) (int h)
+                       (ap/resolve-renderer renderer)
+                       (u/absolute-path path)))))
 
 (defn
   ^{:requires-bindings true

--- a/src/cljc/quil/snippets/environment.cljc
+++ b/src/cljc/quil/snippets/environment.cljc
@@ -38,18 +38,17 @@
   (doseq [type [:arrow :cross :hand :move :text :wait]]
     (q/cursor type)))
 
-(defsnippet cursor-image
-  "cursor-image"
-  {:setup (q/set-state! :image (q/request-image
-                                #?(:cljs "cursor.jpg"
-                                   :clj "test/html/cursor.jpg")))}
+#?(:clj
+   (defsnippet cursor-image
+     "cursor-image"
+     {:setup (q/set-state! :image (q/request-image "test/html/cursor.jpg"))}
 
-  (if (zero? (.-width (q/state :image)))
-    (q/text "Loading" 10 10)
-    (do
-      (q/cursor-image (q/state :image))
-      (q/cursor-image (q/state :image) 16 16)
-      (q/image (q/state :image) 0 0))))
+     (if (zero? (.-width (q/state :image)))
+       (q/text "Loading" 10 10)
+       (do
+         (q/cursor-image (q/state :image))
+         (q/cursor-image (q/state :image) 16 16)
+         (q/image (q/state :image) 0 0)))))
 
 (defsnippet focused
   "focused"

--- a/src/cljc/quil/snippets/image.cljc
+++ b/src/cljc/quil/snippets/image.cljc
@@ -30,7 +30,9 @@
     (dotimes [x 100]
       (dotimes [y 100]
         (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y)))))
+    #?(:cljs (q/update-pixels im))
     (q/image im 0 0)
+
     (comment "resize image from 100x100 to 50x50 and draw again")
     (q/resize im 50 50)
     (q/image im 100 100)))

--- a/src/cljc/quil/snippets/image.cljc
+++ b/src/cljc/quil/snippets/image.cljc
@@ -11,10 +11,12 @@
 
   (q/background 255)
   (comment "create image and draw gradient on it")
-  (let [im (q/create-image 100 100 :rgb)]
+  (let [im (q/create-image 100 100 #?(:clj :rgb))]
     (dotimes [x 100]
       (dotimes [y 100]
         (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y)))))
+    #?(:cljs (q/update-pixels im))
+
     (comment "draw image twice")
     (q/image im 0 0)
     (q/image im 50 50)))
@@ -24,7 +26,7 @@
   {}
 
   (comment "create image and draw gradient on it")
-  (let [im (q/create-image 100 100 :rgb)]
+  (let [im (q/create-image 100 100 #?(:clj :rgb))]
     (dotimes [x 100]
       (dotimes [y 100]
         (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y)))))

--- a/src/cljc/quil/snippets/image/loading_and_displaying.cljc
+++ b/src/cljc/quil/snippets/image/loading_and_displaying.cljc
@@ -135,15 +135,16 @@
     (q/no-tint)
     (q/image gr 200 0)))
 
-(defsnippet request-image
-  "request-image"
-  {:setup
-   (q/set-state! :image
-                 (q/request-image "https://dummyimage.com/100x100/2c3e50/ffffff.png"))}
+#?(:clj
+   (defsnippet request-image
+     "request-image"
+     {:setup
+      (q/set-state! :image
+                    (q/request-image "https://dummyimage.com/100x100/2c3e50/ffffff.png"))}
 
-  (if (zero? (.-width (q/state :image)))
-    (q/text "Loading" 10 10)
-    (q/image (q/state :image) 0 0)))
+     (if (zero? (.-width (q/state :image)))
+       (q/text "Loading" 10 10)
+       (q/image (q/state :image) 0 0))))
 
 (defsnippet tint
   "tint"

--- a/src/cljc/quil/snippets/image/pixels.cljc
+++ b/src/cljc/quil/snippets/image/pixels.cljc
@@ -46,6 +46,7 @@
     (dotimes [x 100]
       (dotimes [y 100]
         (q/set-pixel im x y (q/color (* 2 x) (* 2 y) (+ x y)))))
+    #?(:cljs (q/update-pixels im))
 
     (comment "draw original image")
     (q/image im 0 0)

--- a/src/cljc/quil/snippets/image/pixels.cljc
+++ b/src/cljc/quil/snippets/image/pixels.cljc
@@ -41,7 +41,7 @@
   {}
 
   (q/background 255)
-  (let [im (q/create-image 100 100 :rgb)]
+  (let [im (q/create-image 100 100 #?(:clj :rgb))]
     (comment " gradient on the image")
     (dotimes [x 100]
       (dotimes [y 100]
@@ -227,7 +227,7 @@
   {}
 
   (q/background 255)
-  (let [im (q/create-image 100 100 :rgb)]
+  (let [im (q/create-image 100 100 #?(:clj :rgb))]
     (comment "draw gradient on the image")
     (dotimes [x 100]
       (dotimes [y 100]

--- a/src/cljc/quil/snippets/shape/vertex.cljc
+++ b/src/cljc/quil/snippets/shape/vertex.cljc
@@ -164,23 +164,14 @@
    (defsnippet texture
      "texture"
      {:renderer :p3d
-      :setup (q/set-state! :image (q/request-image "texture.jpg"))}
+      :setup (q/set-state! :image (q/load-image "texture.jpg"))}
 
      (if (zero? (.-width (q/state :image)))
        (q/text "Loading" 10 10)
        (let [gr (q/state :image)]
-         (q/with-translation [250 250]
-           (q/begin-shape)
+         (q/with-translation [50 0]
            (q/texture gr)
-           (q/vertex 50 100 75 100)
-           (q/vertex 100 50 100 75)
-           (q/vertex 100 -50 100 25)
-           (q/vertex 50 -100 75 0)
-           (q/vertex -50 -100 25 0)
-           (q/vertex -100 -50 0 25)
-           (q/vertex -100 50 0 75)
-           (q/vertex -50 100 25 100)
-           (q/end-shape :close))))))
+           (q/plane 200 200))))))
 
 #?(:clj
    (defsnippet texture-mode
@@ -212,34 +203,7 @@
          (q/vertex 0 0 0 0)
          (q/vertex 100 100 1 1)
          (q/vertex 0 100 0 1)
-         (q/end-shape :close))))
-
-   :cljs
-   (defsnippet texture-mode
-     "texture-mode"
-     {:renderer :p3d
-      :setup (q/set-state! :image (q/request-image "texture.jpg"))}
-
-     (if (zero? (.-width (q/state :image)))
-       (q/text "Loading" 10 10)
-       (let [gr (q/state :image)]
-         (q/with-translation [375 125]
-           (q/begin-shape)
-           (q/texture gr)
-           (q/texture-mode :image)
-           (q/vertex 0 0 0 0)
-           (q/vertex 100 100 100 100)
-           (q/vertex 0 100 0 100)
-           (q/end-shape :close))
-
-         (q/with-translation [125 375]
-           (q/begin-shape)
-           (q/texture gr)
-           (q/texture-mode :normal)
-           (q/vertex 0 0 0 0)
-           (q/vertex 100 100 1 1)
-           (q/vertex 0 100 0 1)
-           (q/end-shape :close))))))
+         (q/end-shape :close)))))
 
 #?(:clj
    (defsnippet texture-wrap


### PR DESCRIPTION
* continued with the next section i.e. Image (submitting before done with whole section so the PR doesn't get too big)
* `ellipse-mode` adapted here because it is used by `display-filter` and `image-filter` snippets
* seems `:clj` reader conditionals are missing for `print-camera` and `print-projection`
* not sure why but noticed differences in `display-filter` and `image-filter`: threshold and gray modes giving different output:
<img width="1088" alt="display-filter-screenshot" src="https://user-images.githubusercontent.com/1301852/52230394-87900680-28b7-11e9-958e-1ca3377f3922.png">
