### PR TITLE
Adapt `vertex` for use with p5js.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [quil/processing-svg "3.3.7"]
                  [quil/jogl-all-fat "2.3.2"]
                  [quil/gluegen-rt-fat "2.3.2"]
-                 [cljsjs/p5 "0.7.2-0"]
+                 [cljsjs/p5 "0.7.3-0"]
                  [com.lowagie/itext "2.1.7"]
 
 

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -4450,7 +4450,8 @@
   changed with texture-mode."
   ([x y] (.vertex (current-graphics) (float x) (float y)))
   ([x y z] (.vertex (current-graphics) (float x) (float y) (float z)))
-  ([x y u v] (.vertex (current-graphics) (float x) (float y) (float u) (float v)))
+  ([x y u v] #?(:clj (.vertex (current-graphics) (float x) (float y) (float u) (float v))
+                :cljs (.vertex (current-graphics) (float x) (float y) 0 (float u) (float v))))
   ([x y z u v]
    (.vertex (current-graphics) (float x) (float y) (float z) (float u) (float v))))
 

--- a/src/cljc/quil/snippets/shape/vertex.cljc
+++ b/src/cljc/quil/snippets/shape/vertex.cljc
@@ -227,50 +227,49 @@
          (q/vertex 0 200 0 200)
          (q/end-shape :close)))))
 
-#?(:clj
-   (defsnippet vertex
-     "vertex"
-     {:renderer :p3d}
+(defsnippet vertex
+  "vertex"
+  {:renderer :p3d}
 
-     (q/camera 100 400 200 100 0 0 0 0 -1)
-     (q/line 0 0 0 0 0 100)
-     (q/line 0 0 0 0 100 0)
-     (q/line 0 0 0 100 0 0)
+  (q/camera 100 400 200 100 0 0 0 0 -1)
+  (q/line 0 0 0 0 0 100)
+  (q/line 0 0 0 0 100 0)
+  (q/line 0 0 0 100 0 0)
 
-     (let [txtr (q/create-graphics 100 100)]
-       (q/with-graphics txtr
-         (q/background 255)
-         (q/fill 255 0 0)
-         (q/rect 0 60 100 40)
-         (q/fill 0 150 0)
-         (q/rect 0 0 100 60))
+  (let [txtr (q/create-graphics 100 100)]
+    (q/with-graphics txtr
+      (q/background 255)
+      (q/fill 255 0 0)
+      (q/rect 0 60 100 40)
+      (q/fill 0 150 0)
+      (q/rect 0 0 100 60))
 
-       (q/begin-shape)
-       (q/vertex 0 0)
-       (q/vertex 100 0)
-       (q/vertex 100 100)
-       (q/vertex 0 100)
-       (q/end-shape :close)
+    (q/begin-shape)
+    (q/vertex 0 0)
+    (q/vertex 100 0)
+    (q/vertex 100 100)
+    (q/vertex 0 100)
+    (q/end-shape :close)
 
-       (q/begin-shape)
-       (q/vertex 0 0 0)
-       (q/vertex 100 0 0)
-       (q/vertex 100 0 100)
-       (q/vertex 0 0 100)
-       (q/end-shape :close)
+    (q/begin-shape)
+    (q/vertex 0 0 0)
+    (q/vertex 100 0 0)
+    (q/vertex 100 0 100)
+    (q/vertex 0 0 100)
+    (q/end-shape :close)
 
-       (q/begin-shape)
-       (q/texture txtr)
-       (q/vertex 100 0 0 0)
-       (q/vertex 200 0 100 0)
-       (q/vertex 200 100 100 100)
-       (q/vertex 100 100 0 100)
-       (q/end-shape :close)
+    (q/begin-shape)
+    (q/texture txtr)
+    (q/vertex 100 0 0 0)
+    (q/vertex 200 0 100 0)
+    (q/vertex 200 100 100 100)
+    (q/vertex 100 100 0 100)
+    (q/end-shape :close)
 
-       (q/begin-shape)
-       (q/texture txtr)
-       (q/vertex 100 0 0 0 0)
-       (q/vertex 200 0 0 100 0)
-       (q/vertex 200 0 100 100 100)
-       (q/vertex 100 0 100 0 100)
-       (q/end-shape :close))))
+    (q/begin-shape)
+    (q/texture txtr)
+    (q/vertex 100 0 0 0 0)
+    (q/vertex 200 0 0 100 0)
+    (q/vertex 200 0 100 100 100)
+    (q/vertex 100 0 100 0 100)
+    (q/end-shape :close)))


### PR DESCRIPTION
Upgrade to p5 v0.7.3 necessary as there are bugfixes which affect vertex.
Issue #255.