### PR TITLE
p5 shader

### DIFF
--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -264,6 +264,18 @@
       (let [state-map (apply hash-map state-vals)]
         (reset! state* state-map)))))
 
+#?(:cljs
+   (defn
+     ^{:requires-bindings true
+       :category "Shader"
+       :subcategory nil
+       :added "3.0.0"}
+     set-uniform
+     "Set a uniform variables inside a shader to modify the effect
+     while the program is running."
+     [shader uniform-name data]
+     (.setUniform shader uniform-name data)))
+
 (defn
   ^{:requires-bindings false
     :processing-name "abs()"
@@ -2340,12 +2352,15 @@
     :subcategory "Shaders"
     :added "2.0"}
   load-shader
-  "Loads a shader into the PShader object. Shaders are compatible with the
-  P2D and P3D renderers, but not with the default renderer."
+  "Loads a shader into the PShader object for clj and Shader object for
+  cljs. In clj mode shaders are
+  compatible with the P2D and P3D renderers, but not with the default
+  renderer. In cljs mode shaders are compatible with the P3D renderer."
   ([fragment-filename]
    (.loadShader (current-graphics) fragment-filename))
   ([fragment-filename vertex-filename]
-   (.loadShader (current-graphics) fragment-filename vertex-filename)))
+   #?(:clj (.loadShader (current-graphics) fragment-filename vertex-filename)
+      :cljs (.loadShader (current-graphics) vertex-filename fragment-filename))))
 
 (defn
   ^{:requires-bindings true
@@ -2357,6 +2372,19 @@
   "Load a geometry from a file as a PShape."
   [filename]
   (.loadShape (ap/current-applet) filename))
+
+#?(:cljs
+   (defn
+     ^{:requires-bindings true
+       :processing-name nil
+       :category "Environment"
+       :subcategory nil
+       :added "1.0"}
+     loaded?
+     "Returns true if object is loaded."
+     [object]
+     (condp = (type object)
+       js/p5.Shader (and (aget object "_vertSrc") (aget object "_fragSrc")))))
 
 (defn
   ^{:requires-bindings false
@@ -3604,18 +3632,19 @@
   [x y ^PImage src]
   (.set (current-graphics) (int x) (int y) src))
 
-#?(:clj
-   (defn
-     ^{:requires-bindings true
-       :processing-name "shader()"
-       :category "Rendering"
-       :subcategory "Shaders"
-       :added "2.0"}
-     shader
-     "Applies the shader specified by the parameters. It's compatible with the :p2d
-  and :p3d renderers, but not with the default :java2d renderer. Optional 'kind'
-  parameter - type of shader, either :points, :lines, or :triangles"
-     ([shader] (.shader (current-graphics) shader))
+(defn
+  ^{:requires-bindings true
+    :processing-name "shader()"
+    :category "Rendering"
+    :subcategory "Shaders"
+    :added "2.0"}
+  shader
+  "Applies the shader specified by the parameters. It's compatible with the :p2d
+  and :p3d renderers, but not with the default :java2d renderer.
+  In clj mode you can pass an optional 'kind' parameter that specifies
+  the type of shader, either :points, :lines, or :triangles"
+  ([shader] (.shader (current-graphics) shader))
+  #?(:clj
      ([shader kind]
       (let [mode (u/resolve-constant-key kind shader-modes)]
         (.shader (current-graphics) shader mode)))))

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -2159,8 +2159,8 @@
    (defn
      ^{:requires-bindings true
        :processing-name "lightness()"
-       :category nil
-       :subcategory nil
+       :category "Color"
+       :subcategory "Creating & Reading"
        :added "3.0.0"}
      lightness
      "Extracts the HSL lightness value from a color or pixel array."

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -2373,18 +2373,19 @@
   [filename]
   (.loadShape (ap/current-applet) filename))
 
-#?(:cljs
-   (defn
-     ^{:requires-bindings true
-       :processing-name nil
-       :category "Environment"
-       :subcategory nil
-       :added "1.0"}
-     loaded?
-     "Returns true if object is loaded."
-     [object]
-     (condp = (type object)
-       js/p5.Shader (and (aget object "_vertSrc") (aget object "_fragSrc")))))
+(defn
+  ^{:requires-bindings false
+    :processing-name nil
+    :category "Environment"
+    :subcategory nil
+    :added "3.0.0"}
+  loaded?
+  "Returns true if object is loaded."
+  [object]
+  (condp = (type object)
+    #?@(:clj  (PImage (pos? (.-width object)))
+        :cljs (js/p5.Shader (and (aget object "_vertSrc") (aget object "_fragSrc"))
+               js/p5.Image (pos? (.-width object))))))
 
 (defn
   ^{:requires-bindings false

--- a/src/cljc/quil/snippets/image/loading_and_displaying.cljc
+++ b/src/cljc/quil/snippets/image/loading_and_displaying.cljc
@@ -55,8 +55,8 @@
             (q/set-state! :image (q/load-image url)))}
 
   (let [im (q/state :image)]
-    (comment "image is loaded once its width is non-zero")
-    (when-not (zero? (.-width im))
+    (comment "check if image is loaded using function loaded?")
+    (when (q/loaded? im)
       (q/image im 0 0))))
 
 (defsnippet mask-image

--- a/src/cljc/quil/snippets/rendering.cljc
+++ b/src/cljc/quil/snippets/rendering.cljc
@@ -65,6 +65,20 @@
        (q/reset-shader)
        (q/image gr 250 250))))
 
+#?(:cljs
+   (defsnippet load-shader
+     "load-shader"
+     {:renderer :p3d
+      :setup (let [shd (q/load-shader "shader.frag" "shader.vert")]
+               (q/set-state! :shader shd))}
+
+     (let [shd (q/state :shader)]
+       (when (q/loaded? shd)
+         (q/shader shd)
+         (q/set-uniform shd "p" (array -0.74364388703 0.13182590421))
+         (q/set-uniform shd "r" (* 1.5 (q/exp (* -6.5 (+ 1 (q/sin (/ (q/millis) 2000)))))))
+         (q/quad -1 -1 1 -1 1 1 -1 1)))))
+
 #?(:clj
    (defsnippet clip-no-clip
      ["clip" "no-clip"]

--- a/test/html/shader.frag
+++ b/test/html/shader.frag
@@ -1,0 +1,16 @@
+precision highp float; varying vec2 vPos;
+uniform vec2 p;
+uniform float r;
+const int I = 500;
+void main() {
+  vec2 c = p + vPos * r, z = c;
+  float n = 0.0;
+  for (int i = I; i > 0; i --) {
+    if(z.x*z.x+z.y*z.y > 4.0) {
+      n = float(i)/float(I);
+      break;
+    }
+    z = vec2(z.x*z.x-z.y*z.y, 2.0*z.x*z.y) + c;
+  }
+  gl_FragColor = vec4(0.5-cos(n*17.0)/2.0,0.5-cos(n*13.0)/2.0,0.5-cos(n*23.0)/2.0,1.0);
+}

--- a/test/html/shader.vert
+++ b/test/html/shader.vert
@@ -1,0 +1,3 @@
+precision highp float; varying vec2 vPos;
+attribute vec3 aPosition;
+void main() { vPos = (gl_Position = vec4(aPosition,1.0)).xy; }


### PR DESCRIPTION
Tried to adapt the shader functionality for p5js but running into an issue when loading the shader. The snippet I added should have the same output as [this p5js sample](https://p5js.org/reference/#/p5/loadShader) but in its current form throws an error. If I take [this example](https://github.com/aferriss/p5jsShaderExamples/blob/gh-pages/1_basics/1-1_red/sketch.js) and move the call to `loadShader` from `preload` to `setup` I get the same error message I get from the snippet: `Yikes! An error occurred compiling the vertex shader:ERROR: 0:1: 'undefined' : syntax error`. Should we consider adding support for `preload` to quil? Or is there perhaps another way to block to wait for the shader to load? I've noticed that for `load-image` for example it is recommended to check that width is non-zero.