### PR TITLE
Just tested the p5js branch on IE 11.619.17134.0 and Edge 42.17134.1.0

### DIFF
--- a/src/cljc/quil/snippets/color/setting.cljc
+++ b/src/cljc/quil/snippets/color/setting.cljc
@@ -109,19 +109,19 @@
 
   (comment "grey")
   (q/stroke 120)
-  (q/rect 0 0 100 100)
+  (q/rect 10 10 100 100)
 
   (comment "semitransparent light grey")
   (q/stroke 80 120)
-  (q/rect 70 70 100 100)
+  (q/rect 80 80 100 100)
 
   (comment "green")
   (q/stroke 0 255 0)
-  (q/rect 140 140 100 100)
+  (q/rect 150 150 100 100)
 
   (comment "semitransparent red")
   (q/stroke 255 0 0 120)
-  (q/rect 210 210 100 100))
+  (q/rect 220 220 100 100))
 
 (defsnippet clear
   "clear"


### PR DESCRIPTION
* There is an [issue with p5 v0.7.3](https://github.com/processing/p5.js/issues/3498) which results in a lot of warnings in the console for the vertex functions. Already fixed and [planned to be released](https://github.com/processing/p5.js/milestones) with v0.8.0 end of March.
* On IE11 the following snippets don't render correctly: `camera`, `with-translation-3d`, `with-rotation-3d-around-x`, `with-rotation-3d-around-xy`
* `save` doesn't work on both IE11 and Edge. Error in console:`Object doesn't support property or method 'toBlob'`
* Minor change to `stroke` snippet in order to display everything inside the canvas
