### PR TITLE
Documentation markup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,12 @@
                                   [compojure "1.6.0"]
                                   [clj-http "3.8.0"]
                                   [javax.servlet/servlet-api "2.5"]
-                                  [org.clojure/tools.reader "1.2.2"]]
+                                  [org.clojure/tools.reader "1.2.2"]
+                                  [com.vladsch.flexmark/flexmark "0.34.18"]
+                                  [com.vladsch.flexmark/flexmark-ext-autolink "0.34.18"]
+                                  [com.vladsch.flexmark/flexmark-ext-gfm-tables "0.34.18"]
+                                  [com.vladsch.flexmark/flexmark-ext-anchorlink "0.34.18"]
+                                  [com.vladsch.flexmark/flexmark-ext-wikilink "0.34.18"]]
                    :plugins [[lein-ring "0.12.5"]
                              [lein-cljfmt "0.5.7"]]
                    :source-paths ["dev"]}

--- a/src/clj/quil/snippets/macro.clj
+++ b/src/clj/quil/snippets/macro.clj
@@ -2,43 +2,44 @@
   (:require [quil.util :as u]))
 
 (defmacro defsnippet
-  "Defines a snippet. Snippet is a smalll example of how to use specific
-  Quil function. Snippets used in Quil docs as well as they used for release
-  testing.
+  "Defines a snippet. A snippet is a small example showing how to use a specific
+  Quil function. Snippets are used in Quil docs and for release testing.
 
-  If snippet is intended for clj-only or cljs-only function - use reader conditionals
-  (https://clojure.org/reference/reader#_reader_conditionals) to define snippet only in
-  clj or cljs. Also you can use reader conditionals inside snippet itself if needed.
+  If a snippet is intended for a clj-only or cljs-only function, use reader conditionals
+  (https://clojure.org/reference/reader#_reader_conditionals) to define the snippet only in
+  clj or cljs. You can also use reader conditionals inside the snippet itself if needed.
 
-  If the snippet is not trivial and has multiple parts - it should have comments. These
-  comments will help Quil users to understand better what snippet does when they read
-  Quil API. Because standard clojure comments (the one that start with ;) are stripped in
-  macros instead comments should be added using (comment) macro. Like the following:
+  If the snippet is not trivial and has multiple parts it should have comments. These
+  comments will help Quil users to understand better what the snippet does when they read
+  the Quil API. Since standard clojure comments (the one that start with ;) are stripped in
+  macros, comments should be added using (comment) macro like this:
 
+  ```
   (comment \"Do foo bar\")
   (foo-bar 123)
+  ```
 
-  All (comment) forms will be converted into ';' comments when generating documentation.
+  All `(comment)` forms will be converted into `;` comments when generating the
+  documentation.
 
   Snippets are stored in https://github.com/quil/quil/tree/master/src/cljc/quil/snippets
 
   More info about snippets: https://github.com/quil/quil/wiki/Snippets
 
-  This macro works by storing its parts in a list quil.snippets.all-snippets/all-snippets
-  that later used to generate tests for release testing or generate documentation.
+  This macro works by storing its parts in a list [[quil.snippets.all-snippets/all-snippets]]
+  that is later used to generate tests for release testing or generate documentation.
 
-  Params:
-    name Name of snippet. Doesn't really matter, needs to be unique
-        in the current file. Good default name is the same as function
-        this snippets tests.
-    fns Name of the Quil function name that the snippet tests. Used to
-        to find all snippets for each function when generating documentation.
-        Supports a collection of names if snippet tests few related Quil
-        functions at the same time.
-    opts Map of extra options. Supported options:
-      :renderer Renderer to use for snippet, if not default.
-      :setup Setup function to use. Default is empty.
-    body Body of draw function of the snippet."
+  Parameters:
+    * `name` - Name of snippet. Usually the same as the function
+               the snippet tests. Needs to be unique in the current file.
+    * `fns`  - Name of the Quil function that the snippet tests. Used to
+               to find all snippets for each function when generating documentation.
+               Supports a collection of names if snippet tests few related Quil
+               functions at the same time.
+    * `opts` - Map of extra options. Supported options:
+      - `:renderer` - Renderer to use for the snippet, if not default.
+      - `:setup`    - Setup function to use. Default is empty.
+    * `body` - The body of the `draw` function of the snippet."
   [snip-name fns opts & body]
   (let [setup (:setup opts '())
         mouse-clicked (:mouse-clicked opts '())]

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -32,10 +32,14 @@
     :tag PGraphics}
   current-graphics
   "Graphics currently used for drawing. By default it is sketch graphics,
-  but if called inside with-graphics macro - graphics passed to the macro
+  but if called inside [[with-graphics]] macro - graphics passed to the macro
   is returned. This method should be used if you need to call some methods
-  that are not implemented by quil. Example:
-  (.beginDraw (current-graphics))."
+  that are not implemented by quil.
+
+  Example:
+  ```
+  (.beginDraw (current-graphics))
+  ```"
   []
   (or *graphics*
       #?(:clj (.-g (ap/current-applet))
@@ -223,10 +227,12 @@
     :added "1.0"}
   set-state!
   "Set sketch-specific state. May only be called once (ideally in the
-  setup fn).  Subsequent calls have no effect.
+  setup function). Subsequent calls have no effect.
 
   Example:
-  (set-state! :foo 1 :bar (atom true) :baz (/ (width) 2))"
+  ```
+  (set-state! :foo 1 :bar (atom true) :baz (/ (width) 2))
+  ```"
   [& state-vals]
   (let [state* (state-atom)]
     (when-not @state*
@@ -298,8 +304,8 @@
   "Sets the ambient reflectance for shapes drawn to the screen. This
   is combined with the ambient light component of environment. The
   color components set through the parameters define the
-  reflectance. For example in the default color mode, setting x=255,
-  y=126, z=0, would cause all the red light to reflect and half of the
+  reflectance. For example in the default [[color-mode]], setting `r=255,
+  g=126, b=0`, would cause all the red light to reflect and half of the
   green light to reflect. Used in combination with [[emissive]], [[specular]],
   and [[shininess]] in setting the material properties of shapes."
   ([gray]
@@ -323,7 +329,7 @@
   in the draw to remain persistent in a looping program. Placing them
   in the setup of a looping program will cause them to only have an
   effect the first time through the loop. The effect of the
-  parameters is determined by the current color mode."
+  parameters is determined by the current [[color-mode]]."
   ([red green blue]
    (.ambientLight (current-graphics) (float red) (float green) (float blue)))
   ([red green blue x y z]
@@ -338,7 +344,10 @@
        :subcategory "Trigonometry"
        :added "2.8.0"}
      angle-mode
-     "Sets the current mode of p5 to given mode. Default mode is `:radians`."
+     "Sets the current mode of p5 to given `mode`.
+     Options are:
+     * `:radians` **(default)**
+     * `:degrees`"
      ([mode]
       (let [mode (u/resolve-constant-key mode angle-modes)]
         (.angleMode (current-graphics) mode)))))
@@ -481,7 +490,7 @@
 
   It is not possible to use transparency (alpha) in background colors
   with the main drawing surface, however they will work properly with
-  create-graphics. Converts args to floats."
+  [[create-graphics]]. Converts args to `floats`."
   ([gray] (.background (current-graphics) (float gray)))
   ([gray alpha] (.background (current-graphics) (float gray) (float alpha)))
   ([r g b] (.background (current-graphics) (float r) (float g) (float b)))
@@ -496,7 +505,7 @@
   background-image
   "Specify an image to be used as the background for a sketch. Its
   width and height must be the same size as the sketch window. Images
-  used as background will ignore the current tint setting."
+  used as background will ignore the current [[tint]] setting."
   [^PImage img]
   (.background (current-graphics) img))
 
@@ -508,7 +517,7 @@
     :added "2.0"}
   begin-contour
   "Use the [[begin-contour]] and [[end-contour]] function to create negative
-  shapes within shapes. These functions can only be within a
+  shapes within shapes. These functions can only be used within a
   [[begin-shape]]/[[end-shape]] pair and they only work with the `:p2d` and `:p3d`
   renderers."
   []
@@ -597,7 +606,7 @@
     :subcategory "Curves"
     :added "1.0"}
   bezier-detail
-  "Sets the resolution at which Beziers display. The default value is
+  "Sets the resolution at which Beziers display. The **default** value is
   20. This function is only useful when using the `:p3d` or `:opengl`
   renderer as the default (`:java2d`) renderer does not use this
   information."
@@ -685,38 +694,36 @@
     :added "1.0"}
   blend
   "Blends a region of pixels from one image into another with full alpha
-  channel support. If `src` is not specified it defaults to current-graphics.
+  channel support. If `src` is not specified it defaults to [[current-graphics]].
   If dest is not specified it defaults to [[current-graphics]].
 
   Note: it is recommended to use the [[blend-mode]] function instead of this one.
 
   Available blend modes are:
 
-  | mode         | description |
-  |--------------|-------------|
-  |`:blend`      | linear interpolation of colours: C = A*factor + B
-  |`:add`        | additive blending with white clip:
-  |              |                             C = min(A*factor + B, 255)
-  |`:darkest`    | only the darkest colour succeeds:
-  |              |                             C = min(A*factor, B)
-  |`:lightest`   | only the lightest colour succeeds:
-  |              |                             C = max(A*factor, B)
-  |`:difference` | subtract colors from underlying image.
-  |`:exclusion`  | similar to :difference, but less extreme.
-  |`:multiply`   | Multiply the colors, result will always be darker.
-  |`:screen`     | Opposite multiply, uses inverse values of the colors.
-  |`:overlay`    | A mix of :multiply and :screen. Multiplies dark values
-  |              | and screens light values.
-  |`:hard-light` | :screen when greater than 50% gray, :multiply when
-  |              | lower.
-  |`:soft-light` | Mix of :darkest and :lightest. Works like :overlay,
-  |              | but not as harsh.
-  |`:dodge`      | Lightens light tones and increases contrast, ignores
-  |              | darks.
-  |              | Called \"Color Dodge\" in Illustrator and Photoshop.
-  |`:burn`       | Darker areas are applied, increasing contrast, ignores
-  |              | lights. Called \"Color Burn\" in Illustrator and
-  |              | Photoshop.
+  * `:blend`      - linear interpolation of colours: C = A*factor + B
+  * `:add`        - additive blending with white clip:
+                                                C = min(A*factor + B, 255)
+  * `:darkest`    - only the darkest colour succeeds:
+                                                C = min(A*factor, B)
+  * `:lightest`   - only the lightest colour succeeds:
+                                                C = max(A*factor, B)
+  * `:difference` - subtract colors from underlying image.
+  * `:exclusion`  - similar to `:difference`, but less extreme.
+  * `:multiply`   - Multiply the colors, result will always be darker.
+  * `:screen`     - Opposite multiply, uses inverse values of the colors.
+  * `:overlay`    - A mix of `:multiply` and `:screen`. Multiplies dark values
+                    and screens light values.
+  * `:hard-light` - `:screen` when greater than 50% gray, `:multiply` when
+                    lower.
+  * `:soft-light` - Mix of `:darkest` and `:lightest`. Works like :overlay,
+                    but not as harsh.
+  * `:dodge`      - Lightens light tones and increases contrast, ignores
+                    darks.
+                    Called \"Color Dodge\" in Illustrator and Photoshop.
+  * `:burn`       - Darker areas are applied, increasing contrast, ignores
+                    lights. Called \"Color Burn\" in Illustrator and
+                    Photoshop.
 
   In clj the following blend modes are also supported:
   `:subtract`   - subtractive blending with black clip:
@@ -749,33 +756,31 @@
 
      Available blend modes are:
 
-     | mode         | description |
-     |--------------|-------------|
-     |`:blend`      | linear interpolation of colours: C = A*factor + B
-     |`:add`        | additive blending with white clip:
-     |              |                             C = min(A*factor + B, 255)
-     |`:subtract`   | subtractive blending with black clip:
-     |              |                             C = max(B - A*factor, 0)
-     |`:darkest`    | only the darkest colour succeeds:
-     |              |                             C = min(A*factor, B)
-     |`:lightest`   | only the lightest colour succeeds:
-     |              |                             C = max(A*factor, B)
-     |`:difference` | subtract colors from underlying image.
-     |`:exclusion`  | similar to :difference, but less extreme.
-     |`:multiply`   | Multiply the colors, result will always be darker.
-     |`:screen`     | Opposite multiply, uses inverse values of the colors.
-     |`:overlay`    | A mix of :multiply and :screen. Multiplies dark values
-     |              | and screens light values.
-     |`:hard-light` | :screen when greater than 50% gray, :multiply when
-     |              | lower.
-     |`:soft-light` | Mix of :darkest and :lightest. Works like :overlay,
-     |              | but not as harsh.
-     |`:dodge`      | Lightens light tones and increases contrast, ignores
-     |              | darks.
-     |              | Called \"Color Dodge\" in Illustrator and Photoshop.
-     |`:burn`       | Darker areas are applied, increasing contrast, ignores
-     |              | lights. Called \"Color Burn\" in Illustrator and
-     |              | Photoshop."
+     * `:blend`      - linear interpolation of colours: C = A*factor + B
+     * `:add`        - additive blending with white clip:
+                                                   C = min(A*factor + B, 255)
+     * `:subtract`   - subtractive blending with black clip:
+                                                   C = max(B - A*factor, 0)
+     * `:darkest`    - only the darkest colour succeeds:
+                                                   C = min(A*factor, B)
+     * `:lightest`   - only the lightest colour succeeds:
+                                                   C = max(A*factor, B)
+     * `:difference` - subtract colors from underlying image.
+     * `:exclusion`  - similar to :difference, but less extreme.
+     * `:multiply`   - Multiply the colors, result will always be darker.
+     * `:screen`     - Opposite multiply, uses inverse values of the colors.
+     * `:overlay`    - A mix of :multiply and :screen. Multiplies dark values
+                       and screens light values.
+     * `:hard-light` - :screen when greater than 50% gray, :multiply when
+                       lower.
+     * `:soft-light` - Mix of :darkest and :lightest. Works like :overlay,
+                       but not as harsh.
+     * `:dodge`      - Lightens light tones and increases contrast, ignores
+                       darks.
+                       Called \"Color Dodge\" in Illustrator and Photoshop.
+     * `:burn`       - Darker areas are applied, increasing contrast, ignores
+                       lights. Called \"Color Burn\" in Illustrator and
+                       Photoshop."
      [c1 c2 mode]
      (let [mode (u/resolve-constant-key mode blend-modes)]
        (PApplet/blendColor (u/clj-unchecked-int c1) (u/clj-unchecked-int c2) (int mode)))))
@@ -791,31 +796,29 @@
   There is a choice of the following modes to blend the source pixels (A)
   with the ones of pixels already in the display window (B):
 
-  | mode         | description |
-  |--------------|-------------|
-  |`:blend`      | linear interpolation of colours: C = A*factor + B
-  |`:add`        | additive blending with white clip:
-  |              |                             C = min(A*factor + B, 255)
-  |`:subtract`   | subtractive blending with black clip:
-  |              |                             C = max(B - A*factor, 0)
-  |`:darkest`    | only the darkest colour succeeds:
-  |              |                             C = min(A*factor, B)
-  |`:lightest`   | only the lightest colour succeeds:
-  |              |                             C = max(A*factor, B)
-  |`:difference` | subtract colors from underlying image.
-  |`:exclusion`  | similar to :difference, but less extreme.
-  |`:multiply`   | Multiply the colors, result will always be darker.
-  |`:screen`     | Opposite multiply, uses inverse values of the colors.
-  |`:replace`    | the pixels entirely replace the others and don't utilize
-  |              | alpha (transparency) values.
-  |`:overlay`    | mix of :multiply and :screen. Multiplies dark values,
-  |              | and screens light values.
-  |`:hard-light` | :screen when greater than 50% gray, :multiply when lower.
-  |`:soft-light` | mix of :darkest and :lightest. Works like :overlay, but
-  |              | not as harsh.
-  |`:dodge`      | lightens light tones and increases contrast, ignores darks.
-  |`:burn`       | darker areas are applied, increasing contrast, ignores
-  |              | lights.
+  * `:blend`      - linear interpolation of colours: C = A*factor + B
+  * `:add`        - additive blending with white clip:
+                                                C = min(A*factor + B, 255)
+  * `:subtract`   - subtractive blending with black clip:
+                                                C = max(B - A*factor, 0)
+  * `:darkest`    - only the darkest colour succeeds:
+                                                C = min(A*factor, B)
+  * `:lightest`   - only the lightest colour succeeds:
+                                                C = max(A*factor, B)
+  * `:difference` - subtract colors from underlying image.
+  * `:exclusion`  - similar to `:difference`, but less extreme.
+  * `:multiply`   - Multiply the colors, result will always be darker.
+  * `:screen`     - Opposite multiply, uses inverse values of the colors.
+  * `:replace`    - the pixels entirely replace the others and don't utilize
+                    alpha (transparency) values.
+  * `:overlay`    - mix of `:multiply` and `:screen`. Multiplies dark values,
+                    and screens light values.
+  * `:hard-light` - :screen when greater than 50% gray, `:multiply` when lower.
+  * `:soft-light` - mix of `:darkest` and `:lightest`. Works like :overlay, but
+                    not as harsh.
+  * `:dodge`      - lightens light tones and increases contrast, ignores darks.
+  * `:burn`       - darker areas are applied, increasing contrast, ignores
+                    lights.
 
   Note: in clj `:hard-light`, `:soft-light`, `:overlay`, `:dodge`, `:burn`
   modes are not supported. In cljs `:subtract` mode is not supported.
@@ -874,17 +877,17 @@
   position, pointing to the center of the display window with the Y
   axis as up. The default values are:
 
-  eyeX:     (/ (width) 2.0)
-  eyeY:     (/ (height) 2.0)
-  eyeZ:     (/ (/ (height) 2.0) (tan (/ (* Math/PI 60.0) 360.0)))
-  centerX:  (/ (width) 2.0)
-  centerY:  (/ (height) 2.0)
-  centerZ:  0
-  upX:      0
-  upY:      1
-  upZ:      0
+  * `eyeX`    - `(/ (width) 2.0)`
+  * `eyeY`    - `(/ (height) 2.0)`
+  * `eyeZ`    - `(/ (/ (height) 2.0) (tan (/ (* Math/PI 60.0) 360.0)))`
+  * `centerX` - `(/ (width) 2.0)`
+  * `centerY` - `(/ (height) 2.0)`
+  * `centerZ` - `0`
+  * `upX`     - `0`
+  * `upY`     - `1`
+  * `upZ`     - `0`
 
-  Similar to gluLookAt() in OpenGL, but it first clears the
+  Similar to `gluLookAt()` in OpenGL, but it first clears the
   current camera settings."
   ([] (.camera (current-graphics)))
   ([eyeX eyeY eyeZ centerX centerY centerZ upX upY upZ]
@@ -899,8 +902,8 @@
     :subcategory "Calculation"
     :added "1.0"}
   ceil
-  "Calculates the closest int value that is greater than or equal to
-  the value of the parameter. For example, (ceil 9.03) returns the
+  "Calculates the closest `int` value that is greater than or equal to
+  the value of the parameter. For example, `(ceil 9.03)` returns the
   value 10."
   [n]
   #?(:clj (PApplet/ceil (float n))
@@ -914,10 +917,10 @@
     :added "2.4.0"}
   clear
   "Clears the pixels within a buffer. This function only works on
-  graphics objects created with the (create-graphics) function meaning
-  that you should call it only inside (with-graphics) macro. Unlike
+  graphics objects created with the [[create-graphics]] function meaning
+  that you should call it only inside [[with-graphics]] macro. Unlike
   the main graphics context (the display window), pixels in additional
-  graphics areas created with (create-graphics) can be entirely or
+  graphics areas created with [[create-graphics]] can be entirely or
   partially transparent. This function clears everything in a graphics
   object to make all of the pixels 100% transparent."
   []
@@ -933,8 +936,8 @@
      clip
      "Limits the rendering to the boundaries of a rectangle defined by
   the parameters. The boundaries are drawn based on the state of
-  the (image-mode) function, either :corner, :corners, or :center.
-  To disable use (no-clip)."
+  the [[image-mode]] function, either `:corner`, `:corners`, or `:center`.
+  To disable use [[no-clip]]."
      [x y w h]
      (.clip (current-graphics) (float x) (float y) (float w) (float h))))
 
@@ -947,14 +950,14 @@
   color
   "Creates an integer representation of a color. The parameters are
   interpreted as RGB or HSB values depending on the current
-  color-mode. The default mode is RGB values from 0 to 255 and
-  therefore, the function call (color 255 204 0) will return a bright
+  [[color-mode]]. The default mode is RGB values from 0 to 255 and
+  therefore, the function call `(color 255 204 0)` will return a bright
   yellow. Args are cast to floats.
 
-  r - red or hue value
-  g - green or saturation value
-  b - blue or brightness value
-  a - alpha value"
+  * r - red or hue value
+  * g - green or saturation value
+  * b - blue or brightness value
+  * a - alpha value"
   ([gray] (.color (current-graphics) (float gray)))
   ([gray alpha] (.color (current-graphics) (float gray) (float alpha)))
   ([r g b] (.color (current-graphics) (float r) (float g) (float b)))
@@ -968,13 +971,13 @@
     :added "1.0"}
   color-mode
   "Changes the way Processing interprets color data. Available modes
-  are :rgb and :hsb (and :hsl in clojurescript).
-  By default, the parameters for fill, stroke,
-  background, and color are defined by values between 0 and 255 using
-  the :rgb color model. The color-mode fn is used to change the
+  are `:rgb` and `:hsb` (and `:hsl` in clojurescript).
+  By default, the parameters for [[fill]], [[stroke]],
+  [[background]], and [[color]] are defined by values between 0 and 255 using
+  the `:rgb` color model. The [[color-mode]] function is used to change the
   numerical range used for specifying colors and to switch color
   systems. For example, calling
-  (color-mode :rgb 1.0) will specify that values are specified between
+  `(color-mode :rgb 1.0)` will specify that values are specified between
   0 and 1. The limits for defining colors are altered by setting the
   parameters range1, range2, range3, and range 4."
   ([mode]
@@ -998,11 +1001,12 @@
        :subcategory "3D Primitives"
        :added "3.0.0"}
      cone
-     "Draw a cone with given radius and height.
+     "Draw a cone with given `radius` and `height`.
+
       Optional parameters:
-        detail-x: number of segments, the more segments the smoother geometry default is 24
-        detail-y: number of segments, the more segments the smoother geometry default is 24
-        cap:      whether to draw the base of the cone"
+        * `detail-x` - number of segments, the more segments the smoother geometry default is 24
+        * `detail-y` - number of segments, the more segments the smoother geometry default is 24
+        * `cap`      - whether to draw the base of the cone"
      ([radius height]
       (.cone (current-graphics) (float radius) (float height)))
      ([radius height detail-x]
@@ -1034,9 +1038,9 @@
     :subcategory "Pixels"
     :added "1.0"}
   copy
-  "Copies a region of pixels from one image to another. If src-img
-  is not specified it defaults to current-graphics. If dest-img is not
-  specified - it defaults to current-graphics. If the source
+  "Copies a region of pixels from one image to another. If `src-img`
+  is not specified it defaults to [[current-graphics]]. If `dest-img` is not
+  specified - it defaults to [[current-graphics]]. If the source
   and destination regions aren't the same size, it will automatically
   resize the source pixels to fit the specified target region. No
   alpha information is used in the process, however if the source
@@ -1076,8 +1080,8 @@
        :subcategory "Loading & Displaying"
        :added "1.0"}
      font-available?
-     "Returns true if font (specified as a string) is available on this
-  system, false otherwise"
+     "Returns `true` if font (specified as a string) is available on this
+  system, `false` otherwise"
      [font-str]
      (if (some #{font-str} (available-fonts))
        true
@@ -1092,29 +1096,29 @@
        :added "1.0"}
      create-font
      "Dynamically converts a font to the format used by Processing (a
-     PFont) from either a font name that's installed on the computer, or
-     from a .ttf or .otf file inside the sketches 'data' folder. This
+     `PFont`) from either a font name that's installed on the computer, or
+     from a `.ttf` or `.otf` file inside the sketches 'data' folder. This
      function is an advanced feature for precise control.
 
-     Use available-fonts to obtain the names for the fonts recognized by
+     Use [[available-fonts]] to obtain the names for the fonts recognized by
      the computer and are compatible with this function.
 
-     The size parameter states the font size you want to generate. The
-     smooth parameter specifies if the font should be antialiased or not,
-     and the charset parameter is an array of chars that specifies the
+     The `size` parameter states the font size you want to generate. The
+     `smooth` parameter specifies if the font should be antialiased or not,
+     and the `charset` parameter is an array of chars that specifies the
      characters to generate.
 
-     This function creates a bitmapped version of a font It loads a font
+     This function creates a bitmapped version of a font. It loads a font
      by name, and converts it to a series of images based on the size of
      the font. When possible, the text function will use a native font
      rather than the bitmapped version created behind the scenes with
      create-font. For instance, when using the default renderer
      setting (JAVA2D), the actual native version of the font will be
      employed by the sketch, improving drawing quality and
-     performance. With the :p2d, :p3d, and :opengl renderer settings, the
+     performance. With the `:p2d`, `:p3d`, and `:opengl` renderer settings, the
      bitmapped version will be used. While this can drastically improve
-     speed and appearance, results are poor when exporting if the sketch
-     does not include the .otf or .ttf file, and the requested font is
+     speed and appearance, results are poor when exporting of the sketch
+     does not include the `.otf` or `.ttf` file, and the requested font is
      not available on the machine running the sketch."
      ([name size] (.createFont (ap/current-applet) (str name) (float size)))
      ([name size smooth] (.createFont (ap/current-applet) (str name) (float size) smooth))
@@ -1128,28 +1132,28 @@
     :subcategory "Rendering"
     :added "1.0"}
   create-graphics
-  "Creates and returns a new PGraphics object of the types :p2d, :p3d,
-  :java2d, :pdf. By default :java2d is used. Use this class if you
+  "Creates and returns a new `PGraphics` object of the types `:p2d`, `:p3d`,
+  `:java2d`, `:pdf`. By default `:java2d` is used. Use this class if you
   need to draw into an off-screen graphics buffer. It's not possible
-  to use create-graphics with the :opengl renderer, because it doesn't
-  allow offscreen use. The :pdf renderer requires the filename parameter.
+  to use [[create-graphics]] with the `:opengl` renderer, because it doesn't
+  allow offscreen use. The `:pdf` renderer requires the filename parameter.
 
-  Note: don't use create-graphics in draw in clojurescript, it leaks memory.
+  Note: don't use [[create-graphics]] in draw in clojurescript, it leaks memory.
   You should create graphic in setup and reuse it in draw instead of creating
   a new one.
 
-  It's important to call any drawing commands between (.beginDraw graphics) and
-  (.endDraw graphics) statements or use with-graphics macro. This is also true
-  for any commands that affect drawing, such as smooth or color-mode.
+  It's important to call any drawing commands between `(.beginDraw graphics)` and
+  `(.endDraw graphics)` statements or use [[with-graphics]] macro. This is also true
+  for any commands that affect drawing, such as [[smooth]] or [[color-mode]].
 
-  If you're using :pdf renderer - don't forget to call (.dispose graphics)
-  as last command inside with-graphics macro, otherwise graphics won't be
+  If you're using `:pdf` renderer - don't forget to call `(.dispose graphics)`
+  as last command inside [[with-graphics]] macro, otherwise graphics won't be
   saved.
 
   Unlike the main drawing surface which is completely opaque, surfaces
-  created with create-graphics can have transparency. This makes it
+  created with [[create-graphics]] can have transparency. This makes it
   possible to draw into a graphics and maintain the alpha channel. By
-  using save to write a PNG or TGA file, the transparency of the
+  using save to write a `PNG` or `TGA` file, the transparency of the
   graphics object will be honored."
   ([w h]
    (.createGraphics (ap/current-applet) (int w) (int h)))
@@ -1168,16 +1172,16 @@
     :subcategory nil
     :added "1.0"}
   create-image
-  "Creates a new datatype for storing images (PImage for clj and
-  Image for cljs). This provides a fresh buffer of pixels to play
-  with. Set the size of the buffer with the width and height
+  "Creates a new datatype for storing images (`PImage` for clj and
+  `Image` for cljs). This provides a fresh buffer of pixels to play
+  with. Set the size of the buffer with the `width` and `height`
   parameters.
 
-  In clj the format parameter defines how the pixels are stored.
+  In clj the `format` parameter defines how the pixels are stored.
   See the PImage reference for more information.
-  Possible formats: :rgb, :argb, :alpha (grayscale alpha channel)
+  Possible formats: `:rgb`, `:argb`, `:alpha` (grayscale alpha channel)
 
-  Prefer using create-image over initialising new PImage (or Image)
+  Prefer using [[create-image]] over initialising new `PImage` (or `Image`)
   instances directly."
   #?@(:clj
       ([w h format]
@@ -1217,11 +1221,11 @@
     :added "1.0"}
   cursor
   "Sets the cursor to a predefined symbol or makes it
-  visible if already hidden (after no-cursor was called).
+  visible if already hidden (after [[no-cursor]] was called).
 
-  Available modes: :arrow, :cross, :hand, :move, :text, :wait
+  Available modes: `:arrow`, `:cross`, `:hand`, `:move`, `:text`, `:wait`
 
-  See cursor-image for specifying a generic image as the cursor
+  See [[cursor-image]] for specifying a generic image as the cursor
   symbol (clj only)."
   ([] (.cursor (ap/current-applet)))
   ([cursor-mode]
@@ -1239,7 +1243,7 @@
        :added "1.0"}
      cursor-image
      "Set the cursor to a predefined image. The horizontal and vertical
-     active spots of the cursor may be specified with hx and hy.
+     active spots of the cursor may be specified with `hx` and `hy`.
      It is recommended to make the size 16x16 or 32x32 pixels."
      ([^PImage img] (.cursor (ap/current-applet) img))
      ([^PImage img hx hy] (.cursor (ap/current-applet) img (int hx) (int hy)))))
@@ -1255,9 +1259,9 @@
   specify the beginning control point and the last two parameters
   specify the ending control point. The middle parameters specify the
   start and stop of the curve. Longer curves can be created by putting
-  a series of curve fns together or using curve-vertex. An additional
-  fn called curve-tightness provides control for the visual quality of
-  the curve. The curve fn is an implementation of Catmull-Rom
+  a series of curve functions together or using [[curve-vertex]]. An additional
+  function called [[curve-tightness]] provides control for the visual quality
+  of the curve. The [[curve]] function is an implementation of Catmull-Rom
   splines."
   ([x1 y1 x2 y2 x3 y3 x4 y4]
    (.curve (current-graphics)
@@ -1280,8 +1284,8 @@
     :added "1.0"}
   curve-detail
   "Sets the resolution at which curves display. The default value is
-  20. This function is only useful when using the :p3d or :opengl
-  renderer as the default (:java2d) renderer does not use this
+  20. This function is only useful when using the `:p3d` or `:opengl`
+  renderer as the default (`:java2d`) renderer does not use this
   information."
   [detail]
   (.curveDetail (current-graphics) (int detail)))
@@ -1293,11 +1297,11 @@
     :subcategory "Curves"
     :added "1.0"}
   curve-point
-  "Evaluates the curve at point t for points a, b, c, d. The parameter
-  t varies between 0 and 1, a and d are points on the curve, and b c
-  and are the control points. This can be done once with the x
+  "Evaluates the curve at point `t` for points `a`, `b`, `c`, `d`. The parameter
+  `t` varies between 0 and 1, `a` and `d` are points on the curve, and `b` and `c`
+  are the control points. This can be done once with the x
   coordinates and a second time with the y coordinates to get the
-  location of a curve at t."
+  location of a curve at `t`."
   [a b c d t]
   (.curvePoint (current-graphics) (float a) (float b) (float c) (float d) (float t)))
 
@@ -1321,15 +1325,15 @@
     :added "1.0"}
   curve-tightness
   "Modifies the quality of forms created with curve and
-  curve-vertex. The parameter squishy determines how the curve fits
+  [[curve-vertex]]. The parameter `tightness` determines how the curve fits
   to the vertex points. The value 0.0 is the default value for
-  squishy (this value defines the curves to be Catmull-Rom splines)
+  `tightness` (this value defines the curves to be Catmull-Rom splines)
   and the value 1.0 connects all the points with straight
   lines. Values within the range -5.0 and 5.0 will deform the curves
   but will leave them recognizable and as values increase in
   magnitude, they will continue to deform."
-  [ti]
-  (.curveTightness (current-graphics) (float ti)))
+  [tightness]
+  (.curveTightness (current-graphics) (float tightness)))
 
 (defn
   ^{:requires-bindings true
@@ -1339,13 +1343,13 @@
     :added "1.0"}
   curve-vertex
   "Specifies vertex coordinates for curves. This function may only be
-  used between begin-shape and end-shape and only when there is no
-  mode keyword specified to begin-shape. The first and last points in a
-  series of curve-vertex lines will be used to guide the beginning and
+  used between [[begin-shape]] and [[end-shape]] and only when there is no
+  `mode` keyword specified to [[begin-shape]]. The first and last points in a
+  series of [[curve-vertex]] lines will be used to guide the beginning and
   end of a the curve. A minimum of four points is required to draw a
   tiny curve between the second and third points. Adding a fifth point
-  with curve-vertex will draw the curve between the second, third, and
-  fourth points. The curve-vertex function is an implementation of
+  with [[curve-vertex]] will draw the curve between the second, third, and
+  fourth points. The [[curve-vertex]] function is an implementation of
   Catmull-Rom splines."
   ([x y] (.curveVertex (current-graphics) (float x) (float y)))
   ([x y z] (.curveVertex (current-graphics) (float x) (float y) (float z))))
@@ -1358,7 +1362,7 @@
        :subcategory "3D Primitives"
        :added "3.0.0"}
      cylinder
-     "Draw a cylinder with given radius and height."
+     "Draw a cylinder with given `radius` and `height`."
      ([radius height]
       (.cylinder (current-graphics) (float radius) (float height)))
 
@@ -1386,8 +1390,8 @@
   degrees
   "Converts a radian measurement to its corresponding value in
   degrees. Radians and degrees are two ways of measuring the same
-  thing. There are 360 degrees in a circle and (* 2 Math/PI) radians
-  in a circle. For example, (= 90° (/ Math/PI 2) 1.5707964). All
+  thing. There are 360 degrees in a circle and `(* 2 Math/PI)` radians
+  in a circle. For example, `(= 90° (/ Math/PI 2) 1.5707964)`. All
   trigonometric methods in Processing require their parameters to be
   specified in radians."
   [radians]
@@ -1405,11 +1409,11 @@
      delay-frame
      "Forces the program to stop running for a specified time. Delay
      times are specified in thousandths of a second, therefore the
-     function call (delay 3000) will stop the program for three
-     seconds. Because the screen is updated only at the end of draw,
+     function call `(delay 3000)` will stop the program for three
+     seconds. Because the screen is updated only at the end of `draw`,
      the program may appear to 'freeze', because the screen will not
-     update when the delay fn is used. This function has no affect
-     inside setup."
+     update when the [[delay-frame]] function is used. This function
+     has no effect inside `setup`."
      [freeze-ms]
      (.delay (ap/current-applet) (int freeze-ms))))
 
@@ -1424,13 +1428,13 @@
   direction and is stronger when hitting a surface squarely and weaker
   if it hits at a gentle angle. After hitting a surface, a
   directional lights scatters in all directions. Lights need to be
-  included in the draw fn to remain persistent in a looping
-  program. Placing them in the setup fn of a looping program will cause
+  included in the `draw` function to remain persistent in a looping
+  program. Placing them in the `setup` function of a looping program will cause
   them to only have an effect the first time through the loop. The
-  affect of the r, g, and b parameters is determined by the current
-  color mode. The nx, ny, and nz parameters specify the direction the
-  light is facing. For example, setting ny to -1 will cause the
-  geometry to be lit from below (the light is facing directly upward)"
+  affect of the `r`, `g`, and `b` parameters is determined by the current
+  color mode. The `nx`, `ny`, and `nz` parameters specify the direction the
+  light is facing. For example, setting `ny` to -1 will cause the
+  geometry to be lit from below (the light is facing directly upward)."
   [r g b nx ny nz]
   (.directionalLight (current-graphics) (float r) (float g) (float b)
                      (float nx) (float ny) (float nz)))
@@ -1442,7 +1446,7 @@
     :subcategory "Calculation"
     :added "1.0"}
   dist
-  "Calculates the distance between two points"
+  "Calculates the distance between two points."
   ([x1 y1 x2 y2]
    #?(:clj (PApplet/dist (float x1) (float y1) (float x2) (float y2))
       :cljs (.dist (ap/current-applet) x1 y1 x2 y2)))
@@ -1458,13 +1462,15 @@
     :added "2.5"}
   do-record
   "Macro for drawing on graphics which saves result in the file at the end.
-  Similar to 'with-graphics' macro. do-record assumed to be used with :pdf
-  graphics. Example:
+  Similar to [[with-graphics]] macro. [[do-record]] assumed to be used with `:pdf`
+  graphics.
 
+  Example:
+  ```
   (q/do-record (q/create-graphics 200 200 :pdf \"output.pdf\")
     (q/fill 250 0 0)
     (q/ellipse 100 100 150 150))
-  "
+  ```"
   [graphics & body]
   `(let [gr# ~graphics]
      (with-graphics gr#
@@ -1479,8 +1485,8 @@
     :added "1.0"}
   ellipse
   "Draws an ellipse (oval) in the display window. An ellipse with an
-  equal width and height is a circle.  The origin may be changed with
-  the ellipse-mode function"
+  equal `width` and `height` is a circle. The origin may be changed with
+  the [[ellipse-mode]] function."
   [x y width height]
   (.ellipse (current-graphics) (float x) (float y) (float width) (float height)))
 
@@ -1491,17 +1497,17 @@
     :subcategory "Attributes"
     :added "1.0"}
   ellipse-mode
-  "Modifies the origin of the ellipse according to the specified mode:
+  "Modifies the origin of the ellipse according to the specified `mode`:
 
-  :center  - specifies the location of the ellipse as
-             the center of the shape. (Default).
-  :radius  - similar to center, but the width and height parameters to
-             ellipse specify the radius of the ellipse, rather than the
-             diameter.
-  :corner  - draws the shape from the upper-left corner of its bounding
-             box.
-  :corners - uses the four parameters to ellipse to set two opposing
-             corners of the ellipse's bounding box."
+   * `:center`  - specifies the location of the ellipse as
+                  the center of the shape **(default)**.
+   * `:radius`  - similar to center, but the width and height parameters to
+                  ellipse specify the radius of the ellipse, rather than the
+                  diameter.
+   * `:corner`  - draws the shape from the upper-left corner of its bounding
+                  box.
+   * `:corners` - uses the four parameters to ellipse to set two opposing
+                  corners of the ellipse's bounding box."
   [mode]
   (let [mode (u/resolve-constant-key mode ellipse-modes)]
     (.ellipseMode (current-graphics) mode)))
@@ -1514,10 +1520,11 @@
        :subcategory "3D Primitives"
        :added "3.0.0"}
      ellipsoid
-     "Draw an ellipsoid with given radius
-       Optional parameters:
-         detail-x: number of segments, the more segments the smoother geometry default is 24
-         detail-y: number of segments, the more segments the smoother geometry default is 16"
+     "Draws an ellipsoid with given radius
+
+      Optional parameters:
+        * `detail-x` - number of segments, the more segments the smoother geometry default is 24
+        * `detail-y` - number of segments, the more segments the smoother geometry default is 16"
      ([radius-x radius-y radius-z]
       (.ellipsoid (current-graphics) radius-x radius-y radius-z))
      ([radius-x radius-y radius-z detail-x]
@@ -1534,11 +1541,11 @@
        :added "1.0"}
      emissive
      "Sets the emissive color of the material used for drawing shapes
-  drawn to the screen. Used in combination with ambient, specular, and
-  shininess in setting the material properties of shapes.
+  drawn to the screen. Used in combination with [[ambient]], [[specular]], and
+  [[shininess]] in setting the material properties of shapes.
 
-  If passed one arg - it is assumed to be an int (i.e. a color),
-  multiple args are converted to floats."
+  If passed one arg it is assumed to be an `int` (i.e. a color),
+  multiple args are converted to `floats`."
      ([gray] (.emissive (current-graphics) gray))
      ([r g b] (.emissive (current-graphics) (float r) (float g) (float b)))))
 
@@ -1549,9 +1556,9 @@
     :subcategory "Vertex"
     :added "2.0"}
   end-contour
-  "Use the begin-contour and end-contour function to create negative
+  "Use the [[begin-contour]] and [[end-contour]] function to create negative
   shapes within shapes. These functions can only be within a
-  begin-shape/end-shape pair and they only work with the :p2d and :p3d
+  [[begin-shape]]/[[end-shape]] pair and they only work with the `:p2d` and `:p3d`
   renderers."
   []
   (.endContour (current-graphics)))
@@ -1564,8 +1571,8 @@
        :subcategory "Files"
        :added "1.0"}
      end-raw
-     "Complement to begin-raw; they must always be used together. See
-     the begin-raw docstring for details."
+     "Complement to [[begin-raw]]; they must always be used together. See
+     the [[begin-raw]] docstring for details."
      []
      (.endRaw (current-graphics))))
 
@@ -1576,9 +1583,9 @@
     :subcategory "Vertex"
     :added "1.0"}
   end-shape
-  "May only be called after begin-shape. When end-shape is called,
-  all of image data defined since the previous call to begin-shape is
-  written into the image buffer. The keyword :close may be passed to
+  "May only be called after [[begin-shape]]. When [[end-shape]] is called,
+  all of image data defined since the previous call to [[begin-shape]] is
+  written into the image buffer. The keyword `:close` may be passed to
   close the shape (to connect the beginning and the end)."
   ([] (.endShape (current-graphics)))
   ([mode]
@@ -1596,9 +1603,9 @@
     :subcategory nil
     :added "1.0"}
   exit
-  "Quits/stops/exits the program.  Rather than terminating
-  immediately, exit will cause the sketch to exit after draw has
-  completed (or after setup completes if called during the setup
+  "Quits/stops/exits the program. Rather than terminating
+  immediately, [[exit]] will cause the sketch to exit after `draw` has
+  completed (or after `setup` completes if called during the `setup`
   method). "
   []
   #?(:clj (.exit (ap/current-applet))
@@ -1611,14 +1618,14 @@
     :subcategory "Calculation"
     :added "1.0"}
   exp
-  "Returns Euler's number e (2.71828...) raised to the power of the
-  value parameter."
+  "Returns Euler's number `e` (2.71828...) raised to the power of the
+  `val` parameter."
   [val]
   #?(:clj (PApplet/exp (float val))
      :cljs (.exp (ap/current-applet) val)))
 
 (defn- save-current-fill
-  "Save current fill color vector in the internal state. It can be accessed using (current-fill) function."
+  "Save current fill color vector in the internal state. It can be accessed using [[current-fill]] function."
   [color]
   (swap! (internal-state) assoc :current-fill color))
 
@@ -1631,10 +1638,10 @@
     :subcategory "Setting"
     :added "1.0"}
   fill
-  "Sets the color used to fill shapes. For example, if you run (fill 204 102 0),
+  "Sets the color used to fill shapes. For example, if you run `(fill 204 102 0)`,
   all subsequent shapes will be filled with orange.  This function casts all
-  input as a float. If nil is passed it removes any fill color; equivalent to
-  (no-fill)."
+  input as a `float`. If nil is passed it removes any fill color; equivalent to
+  calling [[no-fill]]."
   ([gray]
     ; provided color might be passed from (current-fill) in which case it's a vector.
     ; In that case just call fill again applying vector to the (fill).
@@ -1667,7 +1674,7 @@
   screen (called a Retina display on OS X or high-dpi on Windows and
   Linux) and a 1 if not. This information is useful for a program to
   adapt to run at double the pixel density on a screen that supports
-  it. Can be used in conjunction with (pixel-density)"
+  it. Can be used in conjunction with [[pixel-density]]."
   ([] (.displayDensity (ap/current-applet)))
   ([display] (.displayDensity (ap/current-applet) display)))
 
@@ -1683,27 +1690,27 @@
   Level defines the quality of the filter and mode may be one of the
   following keywords:
 
-  :threshold - converts the image to black and white pixels depending
-               if they are above or below the threshold defined by
-               the level parameter. The level must be between
-               0.0 (black) and 1.0 (white). If no level is specified,
-               0.5 is used.
-  :gray      - converts any colors in the image to grayscale
-               equivalents. Doesn't work with level.
-  :invert    - sets each pixel to its inverse value. Doesn't work with
-               level.
-  :posterize - limits each channel of the image to the number of
-               colors specified as the level parameter. The parameter can
-               be set to values between 2 and 255, but results are most
-               noticeable in the lower ranges.
-  :blur      - executes a Gaussian blur with the level parameter
-               specifying the extent of the blurring. If no level
-               parameter is used, the blur is equivalent to Gaussian
-               blur of radius 1.
-  :opaque    - sets the alpha channel to entirely opaque. Doesn't work
-               with level.
-  :erode     - reduces the light areas. Doesn't work with level.
-  :dilate    - increases the light areas.  Doesn't work with level."
+  * `:threshold` - converts the image to black and white pixels depending
+                   if they are above or below the threshold defined by
+                   the level parameter. The level must be between
+                   0.0 (black) and 1.0 (white). If no level is specified,
+                   0.5 is used.
+  * `:gray`      - converts any colors in the image to grayscale
+                   equivalents. Doesn't work with level.
+  * `:invert`    - sets each pixel to its inverse value. Doesn't work with
+                   level.
+  * `:posterize` - limits each channel of the image to the number of
+                   colors specified as the level parameter. The parameter can
+                   be set to values between 2 and 255, but results are most
+                   noticeable in the lower ranges.
+  * `:blur`      - executes a Gaussian blur with the level parameter
+                   specifying the extent of the blurring. If no level
+                   parameter is used, the blur is equivalent to Gaussian
+                   blur of radius 1.
+  * `:opaque`    - sets the alpha channel to entirely opaque. Doesn't work
+                   with level.
+  * `:erode`     - reduces the light areas. Doesn't work with level.
+  * `:dilate`    - increases the light areas. Doesn't work with level."
   ([mode]
    (.filter (current-graphics)
             (u/resolve-constant-key mode filter-modes)))
@@ -1721,7 +1728,7 @@
        :added "2.0"}
      filter-shader
      "Originally named filter in Processing Language.
-  Filters the display window with given shader (only in :p2d and :p3d modes)."
+  Filters the display window with given shader (only in `:p2d` and `:p3d` modes)."
      [^PShader shader-obj] (.filter (current-graphics) shader-obj)))
 
 (defn
@@ -1731,8 +1738,8 @@
     :subcategory "Calculation"
     :added "2.0"}
   floor
-  "Calculates the closest int value that is less than or equal to the
-  value of the parameter. For example, (floor 9.03) returns the value 9."
+  "Calculates the closest `int` value that is less than or equal to the
+  value of the parameter. For example, `(floor 9.03)` returns the value 9."
   [n]
   #?(:clj (PApplet/floor (float n))
      :cljs (.floor (ap/current-applet) n)))
@@ -1744,7 +1751,7 @@
     :subcategory nil
     :added "1.0"}
   focused
-  "Returns a boolean value representing whether the applet has focus."
+  "Returns `true` if the applet has focus, `false` otherwise."
   []  (.-focused (ap/current-applet)))
 
 (defn
@@ -1793,7 +1800,7 @@
   "Specifies a new target framerate (number of frames to be displayed every
   second). If the processor is not fast enough to maintain the
   specified rate, it will not be achieved. For example, the function
-  call (frame-rate 30) will attempt to refresh 30 times a second. It
+  call `(frame-rate 30)` will attempt to refresh 30 times a second. It
   is recommended to set the frame rate within setup. The default rate
   is 60 frames per second."
   [new-rate]
@@ -1826,18 +1833,18 @@
   get-pixel
   "Reads the color of any pixel or grabs a section of an image. If no
   parameters are specified, a copy of entire image is returned. Get the
-  value of one pixel by specifying an x,y coordinate. Get a section of
-  the image by specifying an additional width and height parameter.
+  value of one pixel by specifying an `x`,`y` coordinate. Get a section of
+  the image by specifying an additional `width` and `height` parameter.
   If the pixel requested is outside of the image window, black is returned.
   The numbers returned are scaled according to the current color ranges,
   but only RGB values are returned by this function. For example, even though
-  you may have drawn a shape with (color-mode :hsb), the numbers returned
+  you may have drawn a shape with `(color-mode :hsb)`, the numbers returned
   will be in RGB.
 
-  Getting the color of a single pixel with (get x y) is easy, but not
-  as fast as grabbing the data directly using the pixels fn.
+  Getting the color of a single pixel with `(get x y)` is easy, but not
+  as fast as grabbing the data directly using the [[pixels]] function.
 
-  If no img specified - current-graphics is used."
+  If no `img` specified - [[current-graphics]] is used."
   ([] (get-pixel (current-graphics)))
   ([^PImage img] (.get img))
   ([x y] (get-pixel (current-graphics) x y))
@@ -1853,8 +1860,8 @@
     :added "1.0"}
   green
   "Extracts the green value from a color, scaled to match current
-  color-mode. This value is always returned as a float so be careful
-  not to assign it to an int value."
+  [[color-mode]]. This value is always returned as a `float` so be careful
+  not to assign it to an `int` value."
   [col]
   (.green (current-graphics) (u/clj-unchecked-int col)))
 
@@ -1867,7 +1874,7 @@
   "Converts a byte, char, int, or color to a String containing the
   equivalent hexadecimal notation. For example color(0, 102, 153) will
   convert to the String \"FF006699\". This function can help make your
-  geeky debugging sessions much happier. "
+  geeky debugging sessions much happier."
   ([val]
    #?(:clj (PApplet/hex (int val))
       :cljs (.hex (ap/current-applet) val)))
@@ -1904,7 +1911,7 @@
 
   Options:
 
-  :enable-native-fonts - Use the native version fonts when they are
+  * `:enable-native-fonts` - Use the native version fonts when they are
     installed, rather than the bitmapped version from a .vlw
     file. This is useful with the default (or JAVA2D) renderer
     setting, as it will improve font rendering speed. This is not
@@ -1914,9 +1921,9 @@
     font is unavailable. This option can only be set per-sketch, and
     must be called before any use of text-font.
 
-  :disable-native-fonts - Disables native font support.
+  * `:disable-native-fonts` - Disables native font support.
 
-  :disable-depth-test - Disable the zbuffer, allowing you to draw on
+  * `:disable-depth-test` - Disable the zbuffer, allowing you to draw on
     top of everything at will. When depth testing is disabled, items
     will be drawn to the screen sequentially, like a painting. This
     hint is most often used to draw in 3D, then draw in 2D on top of
@@ -1926,32 +1933,32 @@
     but note that with the depth buffer cleared, any 3D drawing that
     happens later in draw will ignore existing shapes on the screen.
 
-  :enable-depth-test - Enables the zbuffer.
+  * `:enable-depth-test` - Enables the zbuffer.
 
-  :enable-depth-sort - Enable primitive z-sorting of triangles and
+  * `:enable-depth-sort` - Enable primitive z-sorting of triangles and
     lines in :p3d and :opengl rendering modes. This can slow
     performance considerably, and the algorithm is not yet perfect.
 
-  :disable-depth-sort - Disables hint :enable-depth-sort
+  * `:disable-depth-sort` - Disables hint :enable-depth-sort
 
-  :disable-opengl-errors - Speeds up the OPENGL renderer setting
+  * `:disable-opengl-errors` - Speeds up the OPENGL renderer setting
      by not checking for errors while running.
 
-  :enable-opengl-errors - Turns on OpenGL error checking
+  * `:enable-opengl-errors` - Turns on OpenGL error checking
 
-  :enable-depth-mask
-  :disable-depth-mask
+  * `:enable-depth-mask`
+  * `:disable-depth-mask`
 
-  :enable-optimized-stroke
-  :disable-optimized-stroke
-  :enable-retina-pixels
-  :disable-retina-pixels
-  :enable-stroke-perspective
-  :disable-stroke-perspective
-  :enable-stroke-pure
-  :disable-stroke-pure
-  :enable-texture-mipmaps
-  :disable-texture-mipmaps
+  * `:enable-optimized-stroke`
+  * `:disable-optimized-stroke`
+  * `:enable-retina-pixels`
+  * `:disable-retina-pixels`
+  * `:enable-stroke-perspective`
+  * `:disable-stroke-perspective`
+  * `:enable-stroke-pure`
+  * `:disable-stroke-pure`
+  * `:enable-texture-mipmaps`
+  * `:disable-texture-mipmaps`
 "
      [hint-type]
      (let [hint-type (if (keyword? hint-type)
@@ -1991,13 +1998,13 @@
   image
   "Displays images to the screen. Processing currently works with GIF,
   JPEG, and Targa images. The color of an image may be modified with
-  the tint function and if a GIF has transparency, it will maintain
-  its transparency. The img parameter specifies the image to display
-  and the x and y parameters define the location of the image from its
+  the [[tint]] function and if a GIF has transparency, it will maintain
+  its transparency. The `img` parameter specifies the image to display
+  and the `x` and `y` parameters define the location of the image from its
   upper-left corner. The image is displayed at its original size
   unless the width and height parameters specify a different size. The
-  image-mode fn changes the way the parameters work. A call to
-  (image-mode :corners) will change the width and height parameters to
+  [[image-mode]] function changes the way the parameters work. A call to
+  `(image-mode :corners)` will change the `width` and `height` parameters to
    define the x and y values of the opposite corner of the image."
   (#?(:clj [^PImage img x y]
       :cljs [img x y])
@@ -2015,31 +2022,31 @@
     :added "2.0"}
   image-filter
   "Originally named filter in Processing Language.
-  Filters given image with the specified mode and level.
-  Level defines the quality of the filter and mode may be one of
+  Filters given image with the specified `mode` and `level`.
+  `level` defines the quality of the filter and `mode` may be one of
   the following keywords:
 
-  :threshold - converts the image to black and white pixels depending
-               if they are above or below the threshold defined by
-               the level parameter. The level must be between
-               0.0 (black) and 1.0 (white). If no level is specified,
-               0.5 is used.
-  :gray      - converts any colors in the image to grayscale
-               equivalents. Doesn't work with level.
-  :invert    - sets each pixel to its inverse value. Doesn't work with
-               level.
-  :posterize - limits each channel of the image to the number of
-               colors specified as the level parameter. The parameter can
-               be set to values between 2 and 255, but results are most
-               noticeable in the lower ranges.
-  :blur      - executes a Gaussian blur with the level parameter
-               specifying the extent of the blurring. If no level
-               parameter is used, the blur is equivalent to Gaussian
-               blur of radius 1.
-  :opaque    - sets the alpha channel to entirely opaque. Doesn't work
-               with level.
-  :erode     - reduces the light areas. Doesn't work with level.
-  :dilate    - increases the light areas.  Doesn't work with level."
+  * `:threshold` - converts the image to black and white pixels depending
+                   if they are above or below the threshold defined by
+                   the level parameter. The level must be between
+                   0.0 (black) and 1.0 (white). If no level is specified,
+                   0.5 is used.
+  * `:gray`      - converts any colors in the image to grayscale
+                   equivalents. Doesn't work with level.
+  * `:invert`    - sets each pixel to its inverse value. Doesn't work with
+                   level.
+  * `:posterize` - limits each channel of the image to the number of
+                   colors specified as the level parameter. The parameter can
+                   be set to values between 2 and 255, but results are most
+                   noticeable in the lower ranges.
+  * `:blur`      - executes a Gaussian blur with the `level` parameter
+                   specifying the extent of the blurring. If no level
+                   parameter is used, the blur is equivalent to Gaussian
+                   blur of radius 1.
+  * `:opaque`    - sets the alpha channel to entirely opaque. Doesn't work
+                   with level.
+  * `:erode`     - reduces the light areas. Doesn't work with `level`.
+  * `:dilate`    - increases the light areas. Doesn't work with `level`."
   ([^PImage img mode]
    (let [mode (u/resolve-constant-key mode filter-modes)]
      (.filter img mode)))
@@ -2054,18 +2061,16 @@
     :subcategory "Loading & Displaying"
     :added "1.0"}
   image-mode
-  "Modifies the location from which images draw. The default mode is :corner.
+  "Modifies the location from which images draw. The default `mode` is `:corner`.
    Available modes are:
 
-  :corner  - specifies the location to be the upper left corner and
-             uses the fourth and fifth parameters of image to set the
-             image's width and height.
-
-  :corners - uses the second and third parameters of image to set the
-             location of one corner of the image and uses the fourth
-             and fifth parameters to set the opposite corner.
-
-  :center  - draw images centered at the given x and y position."
+  * `:corner`  - specifies the location to be the upper left corner and
+                 uses the fourth and fifth parameters of image to set the
+                 image's width and height.
+  * `:corners` - uses the second and third parameters of image to set the
+                 location of one corner of the image and uses the fourth
+                  and fifth parameters to set the opposite corner.
+  * `:center`  - draw images centered at the given x and y position."
   [mode]
   (let [mode (u/resolve-constant-key mode image-modes)]
     (.imageMode (current-graphics) mode)))
@@ -2080,19 +2085,19 @@
   "The variable keyCode is used to detect special keys such as the UP,
   DOWN, LEFT, RIGHT arrow keys and ALT, CONTROL, SHIFT. When checking
   for these keys, it's first necessary to check and see if the key is
-  coded. This is done with the conditional (= (key) CODED).
+  coded. This is done with the conditional `(= (key) CODED)`.
 
   The keys included in the ASCII specification (BACKSPACE, TAB, ENTER,
   RETURN, ESC, and DELETE) do not require checking to see if they key
   is coded, and you should simply use the key variable instead of
-  key-code If you're making cross-platform projects, note that the
+  [[key-code]]. If you're making cross-platform projects, note that the
   ENTER key is commonly used on PCs and Unix and the RETURN key is
   used instead on Macintosh. Check for both ENTER and RETURN to make
   sure your program will work for all platforms.
 
   For users familiar with Java, the values for UP and DOWN are simply
-  shorter versions of Java's KeyEvent.VK_UP and
-  KeyEvent.VK_DOWN. Other keyCode values can be found in the Java
+  shorter versions of Java's `KeyEvent.VK_UP` and
+  `KeyEvent.VK_DOWN`. Other keyCode values can be found in the Java
   KeyEvent reference."
   []
   (.-keyCode (ap/current-applet)))
@@ -2106,7 +2111,7 @@
        :added "2.4.0"}
      key-modifiers
      "Set of key modifiers that were pressed when event happened.
-  Possible modifiers :ctrl, :alt, :shift, :meta. Not available in
+  Possible modifiers `:ctrl`, `:alt`, `:shift`, `:meta`. Not available in
   ClojureScript."
      []
      (let [modifiers
@@ -2159,13 +2164,13 @@
   falloff = 1 / (CONSTANT + d * LINEAR + (d*d) * QUADRATIC)
 
   Like fill, it affects only the elements which are created after it
-  in the code. The default value is (light-falloff 1.0 0.0 0.0).
+  in the code. The default value is `(light-falloff 1.0 0.0 0.0)`.
   Thinking about an ambient light with a falloff can be tricky. It is
   used, for example, if you wanted a region of your scene to be lit
-  ambiently one color and another region to be lit ambiently by
+  ambiently by one color and another region to be lit ambiently by
   another color, you would use an ambient light with location and
   falloff. You can think of it as a point light that doesn't care
-  which direction a surface is facing."
+  which direction a surface it is facing."
      [constant linear quadratic]
      (.lightFalloff (current-graphics) (float constant) (float linear) (float quadratic))))
 
@@ -2177,7 +2182,7 @@
     :added "1.0"}
   lerp-color
   "Calculates a color or colors between two color at a specific
-  increment. The amt parameter is the amount to interpolate between
+  increment. The `amt` parameter is the amount to interpolate between
   the two values where 0.0 equal to the first point, 0.1 is very near
   the first point, 0.5 is half-way in between, etc."
   [c1 c2 amt]
@@ -2194,7 +2199,7 @@
     :added "1.0"}
   lerp
   "Calculates a number between two numbers at a specific
-  increment. The amt parameter is the amount to interpolate between
+  increment. The `amt` parameter is the amount to interpolate between
   the two values where 0.0 equal to the first point, 0.1 is very near
   the first point, 0.5 is half-way in between, etc. The lerp function
   is convenient for creating motion along a straight path and for
@@ -2214,10 +2219,10 @@
      "Sets the default ambient light, directional light, falloff, and
   specular values. The defaults are:
 
-  (ambient-light 128 128 128)
-  (directional-light 128 128 128 0 0 -1)
-  (light-falloff 1 0 0)
-  (light-specular 0 0 0).
+  `(ambient-light 128 128 128)`
+  `(directional-light 128 128 128 0 0 -1)`
+  `(light-falloff 1 0 0)`
+  `(light-specular 0 0 0)`.
 
   Lights need to be included in the draw to remain persistent in a
   looping program. Placing them in the setup of a looping program
@@ -2234,13 +2239,13 @@
        :subcategory "Lights"
        :added "1.0"}
      light-specular
-     "Sets the specular color for lights. Like fill, it affects only the
+     "Sets the specular color for lights. Like [[fill]], it affects only the
   elements which are created after it in the code. Specular refers to
   light which bounces off a surface in a preferred direction (rather
   than bouncing in all directions like a diffuse light) and is used
   for creating highlights. The specular quality of a light interacts
-  with the specular material qualities set through the specular and
-  shininess functions."
+  with the specular material qualities set through the [[specular]] and
+  [[shininess]] functions."
      [r g b]
      (.lightSpecular (current-graphics) (float r) (float g) (float b))))
 
@@ -2253,10 +2258,10 @@
   line
   "Draws a line (a direct path between two points) to the screen. The
   version of line with four parameters draws the line in 2D. To color
-  a line, use the stroke function. A line cannot be filled, therefore
+  a line, use the [[stroke]] function. A line cannot be filled, therefore
   the fill method will not affect the color of a line. 2D lines are
   drawn with a width of one pixel by default, but this can be changed
-  with the stroke-weight function. The version with six parameters
+  with the [[stroke-weight]] function. The version with six parameters
   allows the line to be placed anywhere within XYZ space."
   ([p1 p2] (apply line (concat p1 p2)))
   ([x1 y1 x2 y2] (.line (current-graphics) (float x1) (float y1) (float x2) (float y2)))
@@ -2271,22 +2276,22 @@
     :subcategory "Loading & Displaying"
     :added "1.0"}
   load-font
-  "Loads a font into a variable of type PFont. To load correctly,
+  "Loads a font into a variable of type `PFont`. To load correctly,
   fonts must be located in the data directory of the current sketch.
-  To create a font to use with Processing use the create-font fn.
+  To create a font to use with Processing use the [[create-font]] function.
 
-  Like load-image and other methods that load data, the load-font fn
-  should not be used inside draw, because it will slow down the sketch
+  Like [[load-image]] and other methods that load data, the [[load-font]]
+  function should not be used inside draw, because it will slow down the sketch
   considerably, as the font will be re-loaded from the disk (or
   network) on each frame.
 
-  For most renderers, Processing displays fonts using the .vlw font
+  For most renderers, Processing displays fonts using the `.vlw` font
   format, which uses images for each letter, rather than defining them
-  through vector data. When hint :enable-native-fonts is used with the
+  through vector data. When hint `:enable-native-fonts` is used with the
   JAVA2D renderer, the native version of a font will be used if it is
   installed on the user's machine.
 
-  Using create-font (instead of load-font) enables vector data to be
+  Using [[create-font]] (instead of [[load-font]]) enables vector data to be
   used with the JAVA2D (default) renderer setting. This can be helpful
   when many font sizes are needed, or when using any renderer based on
   JAVA2D, such as the PDF library."
@@ -2300,17 +2305,17 @@
     :subcategory "Loading & Displaying"
     :added "1.0"}
   load-image
-  "Loads an image into a variable of type PImage. Four types of
-  images ( .gif, .jpg, .tga, .png) images may be loaded. To load
+  "Loads an image into a variable of type `PImage`. Four types of
+  images (`.gif`, `.jpg`, `.tga`, `.png`) may be loaded. To load
   correctly, images must be located in the data directory of the
-  current sketch. In most cases, load all images in setup to preload
-  them at the start of the program. Loading images inside draw will
+  current sketch. In most cases, load all images in `setup` to preload
+  them at the start of the program. Loading images inside `draw` will
   reduce the speed of a program.
 
   The filename parameter can also be a URL to a file found online.
 
   Image is loaded asynchronously. In order to check whether image
-  finished loading use (q/loaded? img) function."
+  finished loading use [[loaded?]]."
   [filename]
   #?(:clj (.requestImage (ap/current-applet) (str filename))
      :cljs (.loadImage (ap/current-applet) (str filename))))
@@ -2322,7 +2327,7 @@
     :subcategory "Shaders"
     :added "2.0"}
   load-shader
-  "Loads a shader into the PShader object for clj and Shader object for
+  "Loads a shader into the `PShader` object for clj and `Shader` object for
   cljs. In clj mode shaders are
   compatible with the P2D and P3D renderers, but not with the default
   renderer. In cljs mode shaders are compatible with the P3D renderer."
@@ -2339,7 +2344,7 @@
     :subcategory "Loading & Displaying"
     :added "1.0"}
   load-shape
-  "Load a geometry from a file as a PShape in clj, and a Geometry
+  "Load a geometry from a file as a `PShape` in clj, and a `Geometry`
   in cljs."
   [filename]
   #?(:clj (.loadShape (ap/current-applet) filename)
@@ -2384,8 +2389,8 @@
   "Calculates the magnitude (or length) of a vector. A vector is a
   direction in space commonly used in computer graphics and linear
   algebra. Because it has no start position, the magnitude of a vector
-  can be thought of as the distance from coordinate (0,0) to its (x,y)
-  value. Therefore, mag is a shortcut for writing (dist 0 0 x y)."
+  can be thought of as the distance from coordinate `(0,0)` to its `(x,y)`
+  value. Therefore, [[mag]] is a shortcut for writing `(dist 0 0 x y)`."
   ([a b]
    #?(:clj (PApplet/mag (float a) (float b))
       :cljs (.mag (ap/current-applet) a b)))
@@ -2415,13 +2420,13 @@
     :added "1.0"}
   mask-image
   "Masks part of an image from displaying by loading another image and
-  using it as an alpha channel.  This mask image should only contain
+  using it as an alpha channel. This mask image should only contain
   grayscale data. The mask image needs to be the same size as the image
   to which it is applied.
 
   If single argument function is used - masked image is sketch itself
-  or graphics if used inside with-graphics macro. If you're passing
-  graphics to this function - it works only with :p3d and :opengl renderers.
+  or graphics if used inside [[with-graphics]] macro. If you're passing
+  graphics to this function - it works only with `:p3d` and `:opengl` renderers.
 
   This method is useful for creating dynamically generated alpha
   masks."
@@ -2480,8 +2485,8 @@
     :subcategory "Mouse"
     :added "1.0"}
   mouse-button
-  "The value of the system variable mouseButton is either :left, :right,
-  or :center depending on which button is pressed. nil if no button pressed"
+  "The value of the system variable mouseButton is either `:left`, `:right`,
+  or `:center` depending on which button is pressed. `nil` if no button pressed"
   []
   (let [button-code   (.-mouseButton (ap/current-applet))]
     #?(:clj
@@ -2505,9 +2510,7 @@
     :subcategory "Mouse"
     :added "1.0"}
   mouse-pressed?
-  "Variable storing if a mouse button is pressed. The value of the
-  system variable mousePressed is true if a mouse button is pressed
-  and false if a button is not pressed."
+  "true if a mouse button is pressed, false otherwise."
   []
   #?(:clj (.-mousePressed (ap/current-applet))
      :cljs (.-mouseIsPressed (ap/current-applet))))
@@ -2542,7 +2545,7 @@
        :subcategory nil
        :added "2.4.0"}
      no-clip
-     "Disables the clipping previously started by the clip() function."
+     "Disables the clipping previously started by the [[clip]] function."
      []
      (.noClip (current-graphics))))
 
@@ -2553,7 +2556,7 @@
     :subcategory nil
     :added "1.0"}
   no-cursor
-  "Hides the cursor from view. Will not work when running the in full
+  "Hides the cursor from view. Will not work when running in full
   screen (Present) mode."
   []
   (.noCursor (ap/current-applet)))
@@ -2565,8 +2568,9 @@
     :subcategory "Setting"
     :added "1.0"}
   no-fill
-  "Disables filling geometry. If both no-stroke and no-fill are called,
-  nothing will be drawn to the screen."  []
+  "Disables filling geometry. If both [[no-stroke]] and [[no-fill]] are called,
+  nothing will be drawn to the screen."
+  []
   (.noFill (current-graphics))
   (swap! (internal-state) assoc :current-fill nil))
 
@@ -2645,7 +2649,7 @@
     :added "1.0"}
   noise-seed
   "Sets the seed value for noise. By default, noise produces different
-  results each time the program is run. Set the value parameter to a
+  results each time the program is run. Set the `val` parameter to a
   constant to return the same pseudo-random numbers each time the
   software is run."
   [val]
@@ -2660,7 +2664,7 @@
        :added "1.0"}
      no-lights
      "Disable all lighting. Lighting is turned off by default and enabled
-  with the lights fn. This function can be used to disable lighting so
+  with the [[lights]] function. This function can be used to disable lighting so
   that 2D geometry (which does not require lighting) can be drawn
   after a set of lighted 3D geometry."
      []
@@ -2674,19 +2678,19 @@
     :added "1.0"}
   no-loop
   "Stops Processing from continuously executing the code within
-  draw. If start-loop is called, the code in draw will begin to run
-  continuously again. If using no-loop in setup, it should be the last
+  `draw`. If [[start-loop]] is called, the code in `draw` will begin to run
+  continuously again. If using [[no-loop]] in setup, it should be the last
   line inside the block.
 
-  When no-loop is used, it's not possible to manipulate or access the
-  screen inside event handling functions such as mouse-pressed or
-  key-pressed. Instead, use those functions to call redraw or
-  loop which will run draw, which can update the screen
-  properly. This means that when no-loop has been called, no drawing
-  can happen, and functions like save-frame may not be used.
+  When [[no-loop]] is used, it's not possible to manipulate or access the
+  screen inside event handling functions such as [[mouse-pressed]] or
+  [[key-pressed]]. Instead, use those functions to call [[redraw]] or
+  loop which will run `draw`, which can update the screen
+  properly. This means that when [[no-loop]] has been called, no drawing
+  can happen, and functions like [[save-frame]] may not be used.
 
-  Note that if the sketch is resized, redraw will be called to
-  update the sketch, even after no-loop has been
+  Note that if the sketch is resized, [[redraw]] will be called to
+  update the sketch, even after [[no-loop]] has been
   specified. Otherwise, the sketch would enter an odd state until
   loop was called."
   []
@@ -2713,7 +2717,7 @@
     :added "1.0"}
   no-smooth
   "Draws all geometry with jagged (aliased) edges. Must be called inside
-  :settings handler."
+  `:settings` handler."
   [] (.noSmooth (current-graphics)))
 
 (defn
@@ -2723,8 +2727,8 @@
     :subcategory "Setting"
     :added "1.0"}
   no-stroke
-  "Disables drawing the stroke (outline). If both no-stroke and
-  no-fill are called, nothing will be drawn to the screen."
+  "Disables drawing the stroke (outline). If both [[no-stroke]] and
+  [[no-fill]] are called, nothing will be drawn to the screen."
   []
   (.noStroke (current-graphics))
   (swap! (internal-state) assoc :current-stroke nil))
@@ -2763,11 +2767,11 @@
   "Sets an orthographic projection and defines a parallel clipping
   volume. All objects with the same dimension appear the same size,
   regardless of whether they are near or far from the camera. The
-  parameters to this function specify the clipping volume where left
-  and right are the minimum and maximum x values, top and bottom are
-  the minimum and maximum y values, and near and far are the minimum
+  parameters to this function specify the clipping volume where `left`
+  and `right` are the minimum and maximum x values, `top` and `bottom` are
+  the minimum and maximum y values, and `near` and `far` are the minimum
   and maximum z values. If no parameters are given, the default is
-  used: (ortho 0 width 0 height -10 10)"
+  used: `(ortho 0 width 0 height -10 10)`"
   ([] (.ortho (current-graphics)))
   ([left right bottom top]
    (.ortho (current-graphics) (float left) (float right) (float bottom) (float top)))
@@ -2790,8 +2794,8 @@
   projection. The version of perspective without parameters sets the
   default perspective and the version with four parameters allows the
   programmer to set the area precisely. The default values are:
-  perspective(PI/3.0, width/height, cameraZ/10.0, cameraZ*10.0) where
-  cameraZ is ((height/2.0) / tan(PI*60.0/360.0));"
+  `perspective(PI/3.0, width/height, cameraZ/10.0, cameraZ*10.0)` where
+  `cameraZ` is `((height/2.0) / tan(PI*60.0/360.0))`"
   ([] (.perspective (current-graphics)))
   ([fovy aspect z-near z-far]
    (.perspective (current-graphics) (float fovy) (float aspect)
@@ -2808,7 +2812,7 @@
   on high resolutions screens like Apple Retina displays and Windows
   High-DPI displays. Possible values 1 or 2. Must be called only from
   :settings handler. To get density of the current screen you can use
-  (display-density) function."
+  the [[display-density]] function."
   [density]
   (.pixelDensity (ap/current-applet) density))
 
@@ -2821,8 +2825,8 @@
   pixels
   "Array containing the values for all the pixels in the display
   window or image. This array is therefore the size of the display window. If
-  this array is modified, the update-pixels fn must be called to update
-  the changes. Calls .loadPixels before obtaining the pixel array."
+  this array is modified, the [[update-pixels]] function must be called to
+  update the changes. Calls `.loadPixels` before obtaining the pixel array."
   ([] (pixels (current-graphics)))
 
   ([^PImage img]
@@ -2837,7 +2841,7 @@
        :subcategory "3D Primitives"
        :added "3.0.0"}
      plane
-     "Draw a plane with given a width and height."
+     "Draw a plane with given `width` and `height`."
      [width height]
      (.plane (current-graphics) (float width) (float height))))
 
@@ -2871,11 +2875,15 @@
     :added "1.0"}
   point
   "Draws a point, a coordinate in space at the dimension of one
-  pixel. The first parameter is the horizontal value for the point,
-  the second value is the vertical value for the point, and the
-  optional third value is the depth value. Drawing this shape in 3D
-  using the z parameter requires the :P3D or :opengl renderer to be
-  used."
+  pixel.
+
+  Parameters:
+  * `x` - the horizontal value for the point
+  * `y` - the vertical value for the point
+  * `z` - the depth value (optional)
+
+  Drawing this shape in 3D using the `z` parameter requires the `:p3d`
+  or `:opengl` renderer to be used."
   ([x y] (.point (current-graphics) (float x) (float y)))
   ([x y z] (.point (current-graphics) (float x) (float y) (float z))))
 
@@ -2889,8 +2897,8 @@
   "Adds a point light. Lights need to be included in the draw() to
   remain persistent in a looping program. Placing them in the setup()
   of a looping program will cause them to only have an effect the
-  first time through the loop. The affect of the r, g, and b
-  parameters is determined by the current color mode. The x, y, and z
+  first time through the loop. The affect of the `r`, `g`, and `b`
+  parameters is determined by the current [[color-mode]]. The `x`, `y`, and `z`
   parameters set the position of the light"
   [r g b x y z]
   (.pointLight (current-graphics) (float r) (float g) (float b) (float x) (float y) (float z)))
@@ -2904,9 +2912,9 @@
   pop-matrix
   "Pops the current transformation matrix off the matrix
   stack. Understanding pushing and popping requires understanding the
-  concept of a matrix stack. The push-matrix fn saves the current
-  coordinate system to the stack and pop-matrix restores the prior
-  coordinate system. push-matrix and pop-matrix are used in conjunction
+  concept of a matrix stack. The [[push-matrix]] function saves the current
+  coordinate system to the stack and [[pop-matrix]] restores the prior
+  coordinate system. [[push-matrix]] and [[pop-matrix]] are used in conjunction
   with the other transformation methods and may be embedded to control
   the scope of the transformations."
   []
@@ -2921,10 +2929,10 @@
     :added "1.0"}
   pop-style
   "Restores the prior settings on the 'style stack'. Used in
-  conjunction with push-style. Together they allow you to change the
+  conjunction with [[push-style]]. Together they allow you to change the
   style settings and later return to what you had. When a new style is
-  started with push-style, it builds on the current style information.
-  The push-style and pop-style functions can be nested to provide more
+  started with [[push-style]], it builds on the current style information.
+  The [[push-style]] and [[pop-style]] functions can be nested to provide more
   control"
   []
   #?(:clj (.popStyle (current-graphics))
@@ -2937,11 +2945,11 @@
     :subcategory "Calculation"
     :added "1.0"}
   pow
-  "Facilitates exponential expressions. The pow() function is an
+  "Facilitates exponential expressions. The [[pow]] function is an
   efficient way of multiplying numbers by themselves (or their
-  reciprocal) in large quantities. For example, (pow 3 5) is
-  equivalent to the expression (* 3 3 3 3 3) and (pow 3 -5) is
-  equivalent to (/ 1 (* 3 3 3 3 3))."
+  reciprocal) in large quantities. For example, `(pow 3 5)` is
+  equivalent to the expression `(* 3 3 3 3 3)` and `(pow 3 -5)` is
+  equivalent to `(/ 1 (* 3 3 3 3 3))`."
   [num exponent]
   #?(:clj (PApplet/pow (float num) (float exponent))
      :cljs (.pow (ap/current-applet) num exponent)))
@@ -2991,11 +2999,11 @@
     :added "1.0"}
   push-matrix
   "Pushes the current transformation matrix onto the matrix
-  stack. Understanding push-matrix and pop-matrix requires
-  understanding the concept of a matrix stack. The push-matrix
+  stack. Understanding [[[push-matrix]] and [[pop-matrix]] requires
+  understanding the concept of a matrix stack. The [[push-matrix]]
   function saves the current coordinate system to the stack and
-  pop-matrix restores the prior coordinate system. push-matrix and
-  pop-matrix are used in conjunction with the other transformation
+  [[pop-matrix]] restores the prior coordinate system. [[push-matrix]] and
+  [[pop-matrix]] are used in conjunction with the other transformation
   methods and may be embedded to control the scope of the
   transformations."
   []
@@ -3010,18 +3018,18 @@
     :added "1.0"}
   push-style
   "Saves the current style settings onto a 'style stack'. Use with
-  pop-style which restores the prior settings. Note that these
+  [[pop-style]] which restores the prior settings. Note that these
   functions are always used together. They allow you to change the
   style settings and later return to what you had. When a new style is
-  started with push-style, it builds on the current style
-  information. The push-style and pop-style fns can be embedded to
-  provide more control.
+  started with [[push-style]], it builds on the current style
+  information. The [[push-style]] and [[pop-style]] functions can be
+  embedded to provide more control.
 
   The style information controlled by the following functions are
-  included in the style: fill, stroke, tint, stroke-weight,
-  stroke-cap, stroke-join, image-mode, rect-mode, ellipse-mode,
-  shape-mode, color-mode, text-align, text-font, text-mode, text-size,
-  text-leading, emissive, specular, shininess, and ambient"
+  included in the style: [[fill]], [[stroke]], [[tint]], [[stroke-weight]],
+  [[stroke-cap]], [[stroke-join]], [[image-mode]], [[rect-mode]], [[ellipse-mode]],
+  [[shape-mode]], [[color-mode]], [[text-align]], [[text-font]], [[text-mode]], [[text-size]],
+  [[text-leading]], [[emissive]], [[specular]], [[shininess]], and [[ambient]]."
   []
   #?(:clj (.pushStyle (current-graphics))
      :cljs (.push (current-graphics))))
@@ -3035,7 +3043,7 @@
   quad
   "A quad is a quadrilateral, a four sided polygon. It is similar to a
   rectangle, but the angles between its edges are not constrained to
-  be ninety degrees. The first pair of parameters (x1,y1) sets the
+  be ninety degrees. The first pair of parameters `(x1,y1)` sets the
   first vertex and the subsequent pairs should proceed clockwise or
   counter-clockwise around the defined shape."
   [x1 y1 x2 y2 x3 y3 x4 y4]
@@ -3053,13 +3061,13 @@
     :added "2.0"}
   quadratic-vertex
   "Specifies vertex coordinates for quadratic Bezier curves. Each call to
-  quadratic-vertex defines the position of one control points and one
+  [[quadratic-vertex]] defines the position of one control points and one
   anchor point of a Bezier curve, adding a new segment to a line or shape.
-  The first time quadratic-vertex is used within a begin-shape call, it
-  must be prefaced with a call to vertex to set the first anchor point.
-  This function must be used between begin-shape and end-shape and only
+  The first time [[quadratic-vertex]] is used within a [[begin-shape]] call, it
+  must be prefaced with a call to [[vertex]] to set the first anchor point.
+  This function must be used between [[begin-shape]] and [[end-shape]] and only
   when there is no MODE parameter specified to begin-shape. Using the 3D
-  version requires rendering with :p3d."
+  version requires rendering with `:p3d`."
   ([cx cy x3 y3]
    (.quadraticVertex (current-graphics) (float cx) (float cy) (float x3) (float y3)))
   ([cx cy cz x3 y3 z3]
@@ -3076,8 +3084,7 @@
   radians. Radians and degrees are two ways of measuring the same
   thing. There are 360 degrees in a circle and 2*PI radians in a
   circle. For example, 90° = PI/2 = 1.5707964. All trigonometric
-  methods in Processing require their parameters to be specified in
-  radians."
+  methods require their parameters to be specified in radians."
   [degrees]
   #?(:clj (PApplet/radians (float degrees))
      :cljs (.radians (ap/current-applet) degrees)))
@@ -3091,12 +3098,12 @@
   random
   "Generates random numbers. Each time the random function is called,
   it returns an unexpected value within the specified range. If one
-  parameter is passed to the function it will return a float between
-  zero and the value of the high parameter. The function call (random
-  5) returns values between 0 and 5 (starting at zero, up to but not
-  including 5). If two parameters are passed, it will return a float
+  parameter is passed to the function it will return a `float` between
+  zero and the value of the high parameter. The function call `(random
+  5)` returns values between 0 and 5 (starting at zero, up to but not
+  including 5). If two parameters are passed, it will return a `float`
   with a value between the parameters. The function call
-  (random -5 10.2) returns values starting at -5 up to (but not
+  `(random -5 10.2)` returns values starting at -5 up to (but not
   including) 10.2."
   ([max] (.random (ap/current-applet) (float max)))
   ([min max] (.random (ap/current-applet) (float min) (float max))))
@@ -3138,13 +3145,13 @@
     :subcategory "Random"
     :added "2.0"}
   random-gaussian
-  "Returns a float from a random series of numbers having a mean of 0 and
-  standard deviation of 1. Each time the randomGaussian() function is called,
+  "Returns a `float` from a random series of numbers having a mean of 0 and
+  standard deviation of 1. Each time the [[random-gaussian]] function is called,
   it returns a number fitting a Gaussian, or normal, distribution.
-  There is theoretically no minimum or maximum value that randomGaussian()
+  There is theoretically no minimum or maximum value that [[random-gaussian]]
   might return. Rather, there is just a very low probability that values far
   from the mean will be returned; and a higher probability that numbers near
-  the mean will be returned. ."
+  the mean will be returned."
   []
   (.randomGaussian (ap/current-applet)))
 
@@ -3194,7 +3201,7 @@
   with every angle at ninety degrees. By default, the first two
   parameters set the location of the upper-left corner, the third
   sets the width, and the fourth sets the height. These parameters
-  may be changed with rect-mode.
+  may be changed with [[rect-mode]].
 
   To draw a rounded rectangle, add a fifth parameter, which is used as
   the radius value for all four corners. To use a different radius value
@@ -3214,25 +3221,21 @@
     :subcategory "Attributes"
     :added "1.0"}
   rect-mode
-  "Modifies the location from which rectangles draw. The default mode
-  is :corner. Available modes are:
+  "Modifies the location from which rectangles draw. The default `mode`
+  is `:corner`. Available modes are:
 
-
-  :corner  - Specifies the location to be the upper left corner of the
-             shape and uses the third and fourth parameters of rect to
-             specify the width and height.
-
-  :corners - Uses the first and second parameters of rect to set the
-             location of one corner and uses the third and fourth
-             parameters to set the opposite corner.
-
-  :center  - Draws the image from its center point and uses the third
-             and forth parameters of rect to specify the image's width
-             and height.
-
-  :radius  - Draws the image from its center point and uses the third
-             and forth parameters of rect() to specify half of the
-             image's width and height."
+  * `:corner`  - Specifies the location to be the upper left corner of the
+                 shape and uses the third and fourth parameters of [[rect]] to
+                 specify the width and height.
+  * `:corners` - Uses the first and second parameters of [[rect]] to set the
+                 location of one corner and uses the third and fourth
+                 parameters to set the opposite corner.
+  * `:center`  - Draws the image from its center point and uses the third
+                 and fourth parameters of [[rect]] to specify the image's width
+                 and height.
+  * `:radius`  - Draws the image from its center point and uses the third
+                 and forth parameters of [[rect]] to specify half of the
+                 image's width and height."
 
   [mode]
   (let [mode (u/resolve-constant-key mode rect-modes)]
@@ -3245,7 +3248,8 @@
     :subcategory "Creating & Reading"
     :added "1.0"}
   red
-  "Extracts the red value from a color, scaled to match current color-mode."
+  "Extracts the red value from a color, scaled to match the current
+  [[color-mode]]."
   [c]
   (.red (current-graphics) (u/clj-unchecked-int c)))
 
@@ -3256,17 +3260,17 @@
     :subcategory nil
     :added "1.0"}
   redraw
-  "Executes the code within the draw fn one time (or n times in cljs). 
-  This function allows the program to update the display window only 
-  when necessary, for example when an event registered by mouse-pressed or
-  key-pressed occurs.
+  "Executes the code within the `draw` function one time (or n times in cljs).
+  This function allows the program to update the display window only
+  when necessary, for example when an event registered by [[mouse-pressed]] or
+  [[key-pressed]] occurs.
 
-  In structuring a program, it only makes sense to call redraw
-  within events such as mouse-pressed. This is because redraw does
+  In structuring a program, it only makes sense to call [[redraw]]
+  within events such as [[mouse-pressed]]. This is because [[redraw]] does
   not run draw immediately (it only sets a flag that indicates an
   update is needed).
 
-  Calling redraw within draw has no effect because draw is
+  Calling [[redraw]] within `draw` has no effect because `draw` is
   continuously called anyway."
   ([]
    (.redraw (ap/current-applet)))
@@ -3281,7 +3285,7 @@
     :added "1.0"}
   reset-matrix
   "Replaces the current matrix with the identity matrix. The
-  equivalent function in OpenGL is glLoadIdentity()"
+  equivalent function in OpenGL is `glLoadIdentity()`"
   []
   (.resetMatrix (current-graphics)))
 
@@ -3299,9 +3303,9 @@
        :subcategory "Shaders"
        :added "2.0"}
      reset-shader
-     "Restores the default shaders. Code that runs after (reset-shader) will
-  not be affected by previously defined shaders. Optional 'kind' parameter -
-  type of shader, either :points, :lines, or :triangles"
+     "Restores the default shaders. Code that runs after [[reset-shader]] will
+  not be affected by previously defined shaders. Optional `kind` parameter -
+  type of shader, either `:points`, `:lines`, or `:triangles`"
      ([] (.resetShader (current-graphics)))
      ([kind]
       (let [mode (u/resolve-constant-key kind shader-modes)]
@@ -3317,14 +3321,14 @@
   "Resize the image to a new width and height.
   To make the image scale proportionally, use 0 as the value for the wide or
   high parameter. For instance, to make the width of an image 150 pixels,
-  and change the height using the same proportion, use resize(150, 0).
+  and change the height using the same proportion, use `(resize 150 0)`.
 
-  Even though a PGraphics is technically a PImage, it is not possible
-  to rescale the image data found in a PGraphics.
+  Even though a `PGraphics` is technically a `PImage`, it is not possible
+  to rescale the image data found in a `PGraphics`.
   (It's simply not possible to do this consistently across renderers:
   technically infeasible with P3D, or what would it even do with PDF?)
-  If you want to resize PGraphics content, first get a copy of its image data
-  using the get() method, and call resize() on the PImage that is returned."
+  If you want to resize `PGraphics` content, first get a copy of its image data
+  using the get() method, and call resize() on the `PImage` that is returned."
   [^PImage img w h]
   (.resize img w h))
 
@@ -3334,10 +3338,10 @@
     :added "2.7.0"}
   resize-sketch
   "Resizes sketch.
-  Note about ClojureScript version: if div element is resized by external
-  reasons (for example from js on a page then you still need to call this
+  Note about ClojureScript version: if the `div` element is resized externally
+  (for example from js on a page then you still need to call this
   method in order to tell Quil that size has changed. Currently there is no
-  good way to automatically detect that size of <div> element changed."
+  good way to automatically detect that size of the `<div>` element changed."
   [width height]
   #?(:cljs
      (ap/set-size (ap/current-applet) width height)
@@ -3351,24 +3355,24 @@
     :subcategory nil
     :added "1.0"}
   rotate
-  "Rotates a shape the amount specified by the angle parameter. Angles
+  "Rotates a shape the amount specified by the `angle` parameter. Angles
   should be specified in radians (values from 0 to TWO-PI) or
-  converted to radians with the radians function.
+  converted to radians with the [[radians]] function.
 
   Objects are always rotated around their relative position to the
   origin and positive numbers rotate objects in a clockwise
   direction. Transformations apply to everything that happens after
   and subsequent calls to the function accumulates the effect. For
-  example, calling (rotate HALF-PI) and then (rotate HALF-PI) is the
-  same as (rotate PI). All transformations are reset when draw begins
+  example, calling `(rotate HALF-PI)` and then `(rotate HALF-PI)` is the
+  same as `(rotate PI)`. All transformations are reset when draw begins
   again.
 
   Technically, rotate multiplies the current transformation matrix by
   a rotation matrix. This function can be further controlled by the
-  push-matrix and pop-matrix.
+  [[push-matrix]] and [[pop-matrix]] functions.
 
-  When 4 arguments provides it produces a rotation of angle degrees
-  around the vector x y z. Check examples for to better understand.
+  When 4 arguments are provided it produces a rotation of `angle` degrees
+  around the vector `vx` `vy` `vz`. Check examples to better understand.
   This rotation follows the right-hand rule, so if the vector x y z points
   toward the user, the rotation will be counterclockwise."
   ([angle] (.rotate (current-graphics) (float angle)))
@@ -3384,17 +3388,17 @@
     :subcategory nil
     :added "1.0"}
   rotate-x
-  "Rotates a shape around the x-axis the amount specified by the angle
+  "Rotates a shape around the x-axis the amount specified by the `angle`
   parameter. Angles should be specified in radians (values from 0 to
-  (* PI 2)) or converted to radians with the radians function. Objects
+  (* PI 2)) or converted to radians with the [[radians]] function. Objects
   are always rotated around their relative position to the origin and
   positive numbers rotate objects in a counterclockwise
   direction. Transformations apply to everything that happens after
   and subsequent calls to the function accumulates the effect. For
-  example, calling (rotate-x HALF-PI) and then (rotate-x HALF-PI) is
-  the same as (rotate-x PI). If rotate-x is called within the draw fn,
-  the transformation is reset when the loop begins again. This
-  function requires either the :p3d or :opengl renderer."
+  example, calling `(rotate-x HALF-PI)` and then `(rotate-x HALF-PI)` is
+  the same as `(rotate-x PI)`. If [[rotate-x]] is called within the draw
+  function, the transformation is reset when the loop begins again. This
+  function requires either the `:p3d` or `:opengl` renderer."
   [angle]
   (.rotateX (current-graphics) (float angle)))
 
@@ -3405,17 +3409,17 @@
     :subcategory nil
     :added "1.0"}
   rotate-y
-  "Rotates a shape around the y-axis the amount specified by the angle
+  "Rotates a shape around the y-axis the amount specified by the `angle`
   parameter. Angles should be specified in radians (values from 0
-  to (* PI 2)) or converted to radians with the radians function.
+  to (* PI 2)) or converted to radians with the [[radians]] function.
   Objects are always rotated around their relative position to the
   origin and positive numbers rotate objects in a counterclockwise
   direction. Transformations apply to everything that happens after
   and subsequent calls to the function accumulates the effect. For
-  example, calling (rotate-y HALF-PI) and then (rotate-y HALF-PI) is
-  the same as (rotate-y PI). If rotate-y is called within the draw fn,
-  the transformation is reset when the loop begins again. This
-  function requires either the :p3d or :opengl renderer."
+  example, calling `(rotate-y HALF-PI)` and then `(rotate-y HALF-PI)` is
+  the same as `(rotate-y PI)`. If [[rotate-y]] is called within the draw
+  function, the transformation is reset when the loop begins again. This
+  function requires either the `:p3d` or `:opengl` renderer."
   [angle]
   (.rotateY (current-graphics) (float angle)))
 
@@ -3426,17 +3430,17 @@
     :subcategory nil
     :added "1.0"}
   rotate-z
-  "Rotates a shape around the z-axis the amount specified by the angle
+  "Rotates a shape around the z-axis the amount specified by the `angle`
   parameter. Angles should be specified in radians (values from 0
-  to (* PI 2)) or converted to radians with the radians function.
+  to (* PI 2)) or converted to radians with the [[radians]] function.
   Objects are always rotated around their relative position to the
   origin and positive numbers rotate objects in a counterclockwise
   direction. Transformations apply to everything that happens after
   and subsequent calls to the function accumulates the effect. For
-  example, calling (rotate-z HALF-PI) and then (rotate-z HALF-PI) is
-  the same as (rotate-z PI). If rotate-y is called within the draw fn,
-  the transformation is reset when the loop begins again. This
-  function requires either the :p3d or :opengl renderer."
+  example, calling `(rotate-z HALF-PI)` and then `(rotate-z HALF-PI)` is
+  the same as `(rotate-z PI)`. If [[rotate-y]] is called within the draw
+  function, the transformation is reset when the loop begins again. This
+  function requires either the `:p3d` or `:opengl` renderer."
   [angle]
   (.rotateZ (current-graphics) (float angle)))
 
@@ -3448,7 +3452,7 @@
     :added "1.0"}
   round
   "Calculates the integer closest to the value parameter. For example,
-  (round 9.2) returns the value 9."
+  `(round 9.2)` returns the value 9."
   [val]
   #?(:clj (PApplet/round (float val))
      :cljs (.round (ap/current-applet) val)))
@@ -3478,7 +3482,7 @@
   the filename, the image will save in TIFF format and .tif will be
   added to the name. All images saved from the main drawing window
   will be opaque. To save images without a background, use
-  create-graphics."
+  [[create-graphics]]."
   [filename]
   (.save (current-graphics) (str filename)))
 
@@ -3498,7 +3502,9 @@
   and .ext is one of .tiff, .targa, .png, .jpeg or .jpg
 
   Examples:
-     (save-frame \"pretty-pic-####.jpg\")"
+     ```
+     (save-frame \"pretty-pic-####.jpg\")
+     ```"
      ([name] (.saveFrame (ap/current-applet) (str name)))))
 
 (defn
@@ -3511,15 +3517,15 @@
   "Increases or decreases the size of a shape by expanding and
   contracting vertices. Objects always scale from their relative
   origin to the coordinate system. Scale values are specified as
-  decimal percentages. For example, the function call (scale 2)
+  decimal percentages. For example, the function call `(scale 2)`
   increases the dimension of a shape by 200%. Transformations apply to
   everything that happens after and subsequent calls to the function
-  multiply the effect. For example, calling (scale 2) and then
-  (scale 1.5) is the same as (scale 3). If scale is called within
+  multiply the effect. For example, calling `(scale 2)` and then
+  `(scale 1.5)` is the same as `(scale 3)`. If scale is called within
   draw, the transformation is reset when the loop begins again. Using
-  this function with the z parameter requires specifying :p3d or :opengl
+  this function with the `sz` parameter requires specifying `:p3d` or `:opengl`
   as the renderer. This function can be further controlled by
-  push-matrix and pop-matrix."
+  [[push-matrix]] and [[pop-matrix]]."
   ([s] (.scale (current-graphics) (float s)))
   ([sx sy] (.scale (current-graphics) (float sx) (float sy)))
   ([sx sy sz] (.scale (current-graphics) (float sx) (float sy) (float sz))))
@@ -3573,20 +3579,20 @@
     :subcategory "Pixels"
     :added "1.0"}
   set-pixel
-  "Changes the color of any pixel in the display window. The x and y
-  parameters specify the pixel to change and the color parameter
+  "Changes the color of any pixel in the display window. The `x` and `y`
+  parameters specify the pixel to change and the `c` parameter
   specifies the color value. The color parameter is affected by the
-  current color mode (the default is RGB values from 0 to 255).
+  current [[color-mode]] (the default is RGB values from 0 to 255).
 
-  Setting the color of a single pixel with (set x, y) is easy, but not
-  as fast as putting the data directly into pixels[].
+  Setting the color of a single pixel with `(set-pixel x y)` is easy, but not
+  as fast as putting the data directly into [[pixels]].
 
-  This function ignores imageMode().
+  This function ignores [[image-mode]].
 
   Due to what appears to be a bug in Apple's Java implementation, the
-  point() and set() methods are extremely slow in some circumstances
-  when used with the default renderer. Using :p2d or :p3d will fix the
-  problem. Grouping many calls to point or set-pixel together can also
+  [[point]] and [[set-pixel]] methods are extremely slow in some circumstances
+  when used with the default renderer. Using `:p2d` or `:p3d` will fix the
+  problem. Grouping many calls to [[point]] or [[set-pixel]] together can also
   help. (Bug 1094)"
   ([x y c] (set-pixel (current-graphics) x y c))
   ([^PImage img x y c]
@@ -3599,7 +3605,7 @@
     :subcategory "Pixels"
     :added "1.0"}
   set-image
-  "Writes an image directly into the display window. The x and y
+  "Writes an image directly into the display window. The `x` and `y`
   parameters define the coordinates for the upper-left corner of the
   image."
   [x y ^PImage src]
@@ -3612,10 +3618,10 @@
     :subcategory "Shaders"
     :added "2.0"}
   shader
-  "Applies the shader specified by the parameters. It's compatible with the :p2d
-  and :p3d renderers, but not with the default :java2d renderer.
-  In clj mode you can pass an optional 'kind' parameter that specifies
-  the type of shader, either :points, :lines, or :triangles"
+  "Applies the shader specified by the parameters. It's compatible with the `:p2d`
+  and `:p3d` renderers, but not with the default `:java2d` renderer.
+  In clj mode you can pass an optional `kind` parameter that specifies
+  the type of shader, either `:points`, `:lines`, or `:triangles`"
   ([shader] (.shader (current-graphics) shader))
   #?(:clj
      ([shader kind]
@@ -3630,18 +3636,18 @@
     :added "1.0"}
   shape
   "Displays shapes to the screen. The shapes must have been loaded
-  with load-shape. Processing currently works with SVG shapes
-  only. The sh parameter specifies the shape to display and the x and
-  y parameters define the location of the shape from its upper-left
-  corner. The shape is displayed at its original size unless the width
-  and height parameters specify a different size. The shape-mode
-  fn changes the way the parameters work. A call to
-  (shape-mode :corners), for example, will change the width and height
+  with [[load-shape]]. Processing currently works with SVG shapes
+  only. The `sh` parameter specifies the shape to display and the `x` and
+  `y` parameters define the location of the shape from its upper-left
+  corner. The shape is displayed at its original size unless the `width`
+  and `height` parameters specify a different size. The [[shape-mode]]
+  function changes the way the parameters work. A call to
+  `(shape-mode :corners)` for example, will change the width and height
   parameters to define the x and y values of the opposite corner of
   the shape.
 
-  Note complex shapes may draw awkwardly with the renderers :p2d, :p3d, and
-  :opengl. Those renderers do not yet support shapes that have holes
+  Note complex shapes may draw awkwardly with the renderers `:p2d`, `:p3d`, and
+  `:opengl`. Those renderers do not yet support shapes that have holes
   or complicated breaks."
   ([^PShape sh] #?(:clj (.shape (current-graphics) sh)
                    :cljs (.model (current-graphics) sh)))
@@ -3657,21 +3663,21 @@
     :subcategory nil
     :added "1.0"}
   shear-x
-  "Shears a shape around the x-axis the amount specified by the angle
+  "Shears a shape around the x-axis the amount specified by the `angle`
   parameter. Angles should be specified in radians (values from 0 to
-  PI*2) or converted to radians with the radians() function. Objects
+  PI*2) or converted to radians with the [[radians]] function. Objects
   are always sheared around their relative position to the origin and
   positive numbers shear objects in a clockwise direction.
   Transformations apply to everything that happens after and
   subsequent calls to the function accumulates the effect. For
-  example, calling (shear-x (/ PI 2)) and then (shear-x (/ PI 2)) is
-  the same as (shear-x PI). If shear-x is called within the draw fn,
-  the transformation is reset when the loop begins again. This
+  example, calling `(shear-x (/ PI 2))` and then `(shear-x (/ PI 2))` is
+  the same as `(shear-x PI)`. If [[shear-x]] is called within the draw
+  function, the transformation is reset when the loop begins again. This
   function works in P2D or JAVA2D mode.
 
-  Technically, shear-x multiplies the current transformation matrix
+  Technically, [[shear-x]] multiplies the current transformation matrix
   by a rotation matrix. This function can be further controlled by the
-  push-matrix and pop-matrix fns."
+  [[push-matrix]] and [[pop-matrix]] functions."
   [angle]
   (.shearX (current-graphics) (float angle)))
 
@@ -3682,21 +3688,21 @@
     :subcategory nil
     :added "1.0"}
   shear-y
-  "Shears a shape around the y-axis the amount specified by the angle
+  "Shears a shape around the y-axis the amount specified by the `angle`
   parameter. Angles should be specified in radians (values from 0 to
-  PI*2) or converted to radians with the radians() function. Objects
+  PI*2) or converted to radians with the [[radians]] function. Objects
   are always sheared around their relative position to the origin and
   positive numbers shear objects in a clockwise direction.
   Transformations apply to everything that happens after and
   subsequent calls to the function accumulates the effect. For
-  example, calling (shear-y (/ PI 2)) and then (shear-y (/ PI 2)) is
-  the same as (shear-y PI). If shear-y is called within the draw fn,
-  the transformation is reset when the loop begins again. This
+  example, calling `(shear-y (/ PI 2))` and then `(shear-y (/ PI 2))` is
+  the same as `(shear-y PI)`. If [[shear-y]] is called within the draw
+  function, the transformation is reset when the loop begins again. This
   function works in P2D or JAVA2D mode.
 
-  Technically, shear-y multiplies the current transformation matrix
+  Technically, [[shear-y]] multiplies the current transformation matrix
   by a rotation matrix. This function can be further controlled by the
-  push-matrix and pop-matrix fns."
+  [[push-matrix]] and [[pop-matrix]] functions."
   [angle]
   (.shearY (current-graphics) (float angle)))
 
@@ -3707,20 +3713,17 @@
            :subcategory "Loading & Displaying"
            :added "1.0"}
      shape-mode
-     "Modifies the location from which shapes draw. Available modes are
-     :corner, :corners and :center. Default is :corner.
+     "Modifies the location from which shapes draw. Available modes are:
 
-     :corner  - specifies the location to be the upper left corner of the
-                shape and uses the third and fourth parameters of shape
-                to specify the width and height.
-
-     :corners - uses the first and second parameters of shape to set
-                the location of one corner and uses the third and fourth
-                parameters to set the opposite corner.
-
-     :center  - draws the shape from its center point and uses the third
-                and forth parameters of shape to specify the width and
-                height. "
+     * `:corner`  - specifies the location to be the upper left corner of the
+                    shape and uses the third and fourth parameters of shape
+                    to specify the width and height. **(default)**
+     * `:corners` - uses the first and second parameters of shape to set
+                    the location of one corner and uses the third and fourth
+                    parameters to set the opposite corner.
+     * `:center`  - draws the shape from its center point and uses the third
+                    and forth parameters of shape to specify the width and
+                    height."
      [mode]
      (let [mode (u/resolve-constant-key mode p-shape-modes)]
        (.shapeMode (current-graphics) (int mode)))))
@@ -3734,7 +3737,7 @@
        :added "1.0"}
      shininess
      "Sets the amount of gloss in the surface of shapes. Used in
-  combination with ambient, specular, and emissive in setting
+  combination with [[ambient]], [[specular]], and [[emissive]] in setting
   the material properties of shapes."
      [shine]
      (.shininess (current-graphics) (float shine))))
@@ -3748,7 +3751,7 @@
   sin
   "Calculates the sine of an angle. This function expects the values
   of the angle parameter to be provided in radians (values from 0 to
-  6.28). A float within the range -1 to 1 is returned."
+  6.28). A `float` within the range -1 to 1 is returned."
   [angle]
   #?(:clj (PApplet/sin (float angle))
      :cljs (.sin (ap/current-applet) angle)))
@@ -3764,15 +3767,15 @@
   down the frame rate of the application, but will enhance the visual
   refinement.
 
-  Must be called inside :settings handler.
+  Must be called inside `:settings` handler.
 
-  The level parameter (int) increases the level of smoothness with the
-  P2D and P3D renderers. This is the level of over sampling applied to
-  the graphics buffer. The value '2' will double the rendering size
-  before scaling it down to the display size. This is called '2x
-  anti-aliasing.' The value 4 is used for 4x anti-aliasing and 8 is
-  specified for 8x anti-aliasing. If level is set to 0, it will disable
-  all smoothing; it's the equivalent of the function noSmooth().
+  The `level` parameter (int) increases the level of smoothness with the
+  `:p2d` and `:p3d` renderers. This is the level of over sampling applied to
+  the graphics buffer. The value `2` will double the rendering size
+  before scaling it down to the display size. This is called `2x
+  anti-aliasing`. The value `4` is used for `4x anti-aliasing` and `8` is
+  specified for `8x anti-aliasing`. If level is set to `0`, it will disable
+  all smoothing; it's the equivalent of the function [[no-smooth]].
   The maximum anti-aliasing level is determined by the hardware of the
   machine that is running the software.
 
@@ -3794,7 +3797,7 @@
   the screen, which sets the color of highlights. Specular refers to
   light which bounces off a surface in a preferred direction (rather
   than bouncing in all directions like a diffuse light). Used in
-  combination with emissive, ambient, and shininess in setting
+  combination with [[emissive]], [[ambient]], and [[shininess]] in setting
   the material properties of shapes."
   ([gray]
    #?(:clj (.specular (current-graphics) (float gray))
@@ -3826,9 +3829,9 @@
   creates a fairly detailed sphere definition with vertices every
   360/30 = 12 degrees. If you're going to render a great number of
   spheres per frame, it is advised to reduce the level of detail using
-  this function. The setting stays active until sphere-detail is
+  this function. The setting stays active until [[sphere-detail]] is
   called again with a new parameter and so should not be called prior
-  to every sphere statement, unless you wish to render spheres with
+  to every [[sphere]] statement, unless you wish to render spheres with
   different settings, e.g. using less detail for smaller spheres or
   ones further away from the camera. To control the detail of the
   horizontal and vertical resolution independently, use the version of
@@ -3847,10 +3850,10 @@
      "Adds a spot light. Lights need to be included in the draw to
   remain persistent in a looping program. Placing them in the setup
   of a looping program will cause them to only have an effect the
-  first time through the loop. The affect of the r, g, and b
-  parameters is determined by the current color mode. The x, y, and z
-  parameters specify the position of the light and nx, ny, nz specify
-  the direction or light. The angle parameter affects angle of the
+  first time through the loop. The affect of the `r`, `g`, and `b`
+  parameters is determined by the current [[color-mode]]. The `x`, `y`, and `z`
+  parameters specify the position of the light and `nx`, `ny`, `nz` specify
+  the direction or light. The angle parameter affects the angle of the
   spotlight cone."
      ([r g b x y z nx ny nz angle concentration]
       (.spotLight (current-graphics) r g b x y z nx ny nz angle concentration))
@@ -3880,7 +3883,7 @@
   sqrt
   "Calculates the square root of a number. The square root of a number
   is always positive, even though there may be a valid negative
-  root. The square root s of number a is such that (= a (* s s)) . It
+  root. The square root s of number a is such that (= a (* s s)). It
   is the opposite of squaring."
   [a]
   #?(:clj (PApplet/sqrt (float a))
@@ -3894,13 +3897,14 @@
     :added "1.0"}
   start-loop
   "Causes Processing to continuously execute the code within
-  draw. If no-loop is called, the code in draw stops executing."
+  draw. If [[no-loop]] is called, the code in draw stops executing."
   []
   (.loop (ap/current-applet))
   (swap! (internal-state) assoc :looping? true))
 
 (defn- save-current-stroke
-  "Save current stroke color vector in the internal state. It can be accessed using (current-stroke) function."
+  "Save current stroke color vector in the internal state. It can be accessed
+  using the [[current-stroke]] function."
   [color]
   (swap! (internal-state) assoc :current-stroke color))
 
@@ -3913,9 +3917,9 @@
   stroke
   "Sets the color used to draw lines and borders around shapes. This
   color is either specified in terms of the RGB or HSB color depending
-  on the current color-mode (the default color space is RGB, with
+  on the current [[color-mode]] (the default color space is RGB, with
   each value in the range from 0 to 255).
-  If nil is passed it removes any fill color; equivalent to (no-stroke)."
+  If nil is passed it removes any fill color; equivalent to [[no-stroke]]."
   ([gray]
     ; provided color might be passed from (current-fill) in which case it's a vector.
     ; In that case just call fill again applying vector to the (fill).
@@ -3943,7 +3947,7 @@
   stroke-cap
   "Sets the style for rendering line endings. These ends are either
   squared, extended, or rounded and specified with the corresponding
-  parameters :square, :project, and :round. The default cap is :round."
+  parameters `:square`, `:project`, and `:round`. The default cap is `:round`."
   [cap-mode]
   (let [cap-mode (u/resolve-constant-key cap-mode stroke-cap-modes)]
     (.strokeCap (current-graphics)
@@ -3959,10 +3963,10 @@
   stroke-join
   "Sets the style of the joints which connect line
   segments. These joints are either mitered, beveled, or rounded and
-  specified with the corresponding parameters :miter, :bevel, and
-  :round. The default joint is :miter.
+  specified with the corresponding parameters `:miter`, `:bevel`, and
+  `:round`. The default joint is `:miter`.
 
-  This function is not available with the :p2d, :p3d, or :opengl
+  This function is not available with the `:p2d`, `:p3d`, or `:opengl`
   renderers."
   [join-mode]
   (let [join-mode (u/resolve-constant-key join-mode stroke-join-modes)]
@@ -4003,7 +4007,7 @@
     :subcategory nil
     :added "1.5.0"}
   target-frame-rate
-  "Returns the target framerate specified with the fn frame-rate"
+  "Returns the target framerate specified with the function [[frame-rate]]"
   []
   (:frame-rate @(internal-state)))
 
@@ -4014,8 +4018,8 @@
     :subcategory "Loading & Displaying"
     :added "1.0"}
   text-char
-  "Draws a char to the screen in the specified position. See text fn
-  for more details."
+  "Draws a char to the screen in the specified position. See the
+  [[text]] function for more details."
   ([c x y]
    (when (current-fill)
      (.text (current-graphics) (char c) (float x) (float y))))
@@ -4030,8 +4034,8 @@
     :subcategory "Loading & Displaying"
     :added "1.0"}
   text-num
-  "Draws a number to the screen in the specified position. See text fn
-  for more details."
+  "Draws a number to the screen in the specified position. See the
+  [[text]] function for more details."
   ([num x y]
    (when (current-fill)
      (.text (current-graphics) (float num) (float x) (float y))))
@@ -4046,17 +4050,17 @@
     :subcategory "Loading & Displaying"
     :added "1.0"}
   text
-  "Draws text to the screen in the position specified by the x and y
-  parameters (and the optional z parameter in clj). A default font will be used
-  unless a font is set with the text-font fn. Change the color of the
-  text with the fill fn. The text displays in relation to the
-  text-align fn, which gives the option to draw to the left, right, and
+  "Draws text to the screen in the position specified by the `x` and `y`
+  parameters (and the optional `z` parameter in clj). A default font will be used
+  unless a font is set with the [[text-font]] function. Change the color of the
+  text with the [[fill]] function. The text displays in relation to the
+  [[text-align]] function, which gives the option to draw to the left, right, and
   center of the coordinates.
 
-  The x1, y1, x2 and y2 parameters define a
+  The `x1`, `y1`, `x2` and `y2` parameters define a
   rectangular area to display within and may only be used with string
   data. For text drawn inside a rectangle, the coordinates are
-  interpreted based on the current rect-mode setting."
+  interpreted based on the current [[rect-mode]] setting."
   ([^String s x y]
    (when (current-fill)
      (.text (current-graphics) s (float x) (float y))))
@@ -4077,25 +4081,25 @@
   text-align
   "Sets the current alignment for drawing text. Available modes are:
 
-  horizontal - :left, :center, and :right
-  vertical   - :top, :bottom, :center, and :baseline
+  horizontal - `:left`, `:center`, and `:right`
+  vertical   - `:top`, `:bottom`, `:center`, and `:baseline`
 
   An optional second parameter specifies the vertical alignment
-  mode. :baseline is the default. The :top and :center parameters are
-  straightforward. The :bottom parameter offsets the line based on the
-  current text-descent. For multiple lines, the final line will be
+  mode. `:baseline` is the default. The `:top` and `:center` parameters are
+  straightforward. The `:bottom` parameter offsets the line based on the
+  current [[text-descent]]. For multiple lines, the final line will be
   aligned to the bottom, with the previous lines appearing above it.
 
-  When using text with width and height parameters, :baseline is
-  ignored, and treated as :top. (Otherwise, text would by default draw
-  outside the box, since :baseline is the default setting. :baseline is
+  When using text with width and height parameters, `:baseline` is
+  ignored, and treated as `:top`. (Otherwise, text would by default draw
+  outside the box, since `:baseline` is the default setting. `:baseline` is
   not a useful drawing mode for text drawn in a rectangle.)
 
-  The vertical alignment is based on the value of text-ascent, which
+  The vertical alignment is based on the value of [[text-ascent]], which
   many fonts do not specify correctly. It may be necessary to use a
   hack and offset by a few pixels by hand so that the offset looks
   correct. To do this as less of a hack, use some percentage of
-  text-ascent or text-descent so that the hack works even if you
+  [[text-ascent]] or [[text-descent]] so that the hack works even if you
   change the size of the font."
   ([align]
    (let [align (u/resolve-constant-key align horizontal-alignment-modes)]
@@ -4114,7 +4118,7 @@
   text-ascent
   "Returns the ascent of the current font at its current size. This
   information is useful for determining the height of the font above
-  the baseline. For example, adding the text-ascent and text-descent
+  the baseline. For example, adding the [[text-ascent]] and [[text-descent]]
   values will give you the total height of the line."
   []
   (.textAscent (current-graphics)))
@@ -4128,7 +4132,7 @@
   text-descent
   "Returns descent of the current font at its current size. This
   information is useful for determining the height of the font below
-  the baseline. For example, adding the text-ascent and text-descent
+  the baseline. For example, adding the [[text-ascent]] and [[text-descent]]
   values will give you the total height of the line."
   []
   (.textDescent (current-graphics)))
@@ -4141,21 +4145,21 @@
     :added "1.0"}
   text-font
   "Sets the current font that will be drawn with the text
-  function. Fonts must be loaded with load-font before it can be
-  used. This font will be used in all subsequent calls to the text
-  function. If no size parameter is input, the font will appear at its
-  original size until it is changed with text-size.
+  function. Fonts must be loaded with [[load-font]] before it can be
+  used. This font will be used in all subsequent calls to the [[text]]
+  function. If no `size` parameter is input, the font will appear at its
+  original size until it is changed with [[text-size]].
 
   Because fonts are usually bitmaped, you should create fonts at the
-  sizes that will be used most commonly. Using textFont without the
-  size parameter will result in the cleanest-looking text.
+  sizes that will be used most commonly. Using [[text-font]] without the
+  `size` parameter will result in the cleanest-looking text.
 
   With the default (JAVA2D) and PDF renderers, it's also possible to
   enable the use of native fonts via the command
-  (hint :enable-native-fonts). This will produce vector text in JAVA2D
+  `(hint :enable-native-fonts)`. This will produce vector text in JAVA2D
   sketches and PDF output in cases where the vector data is available:
   when the font is still installed, or the font is created via the
-  create-font fn"
+  [[create-font]] function."
   ([^PFont font] (.textFont (current-graphics) font))
   ([^PFont font size] (.textFont (current-graphics) font (int size))))
 
@@ -4167,7 +4171,7 @@
     :added "1.0"}
   text-leading
   "Sets the spacing between lines of text in units of pixels. This
-  setting will be used in all subsequent calls to the text function."
+  setting will be used in all subsequent calls to the [[text]] function."
   [leading]
   (.textLeading (current-graphics) (float leading)))
 
@@ -4180,23 +4184,23 @@
        :added "1.0"}
      text-mode
      "Sets the way text draws to the screen - available modes
-     are :model and :shape
+     are `:model` and `:shape`
 
-     In the default configuration (the :model mode), it's possible to
+     In the default configuration (the `:model` mode), it's possible to
      rotate, scale, and place letters in two and three dimensional space.
 
-     The :shape mode draws text using the glyph outlines of individual
+     The `:shape` mode draws text using the glyph outlines of individual
      characters rather than as textures. This mode is only supported with
      the PDF and OPENGL renderer settings. With the PDF renderer, you
-     must specify the :shape text-mode before any other drawing occurs.
-     If the outlines are not available, then :shape will be ignored and
-     :model will be used instead.
+     must specify the `:shape` [[text-mode]] before any other drawing occurs.
+     If the outlines are not available, then `:shape` will be ignored and
+     `:model` will be used instead.
 
-     The :shape option in OPENGL mode can be combined with begin-raw to
+     The `:shape` option in OPENGL mode can be combined with [[begin-raw]] to
      write vector-accurate text to 2D and 3D output files, for instance
-     DXF or PDF. :shape is not currently optimized for OPENGL, so if
-     recording shape data, use :model until you're ready to capture the
-     geometry with begin-raw."
+     DXF or PDF. `:shape` is not currently optimized for OPENGL, so if
+     recording shape data, use `:model` until you're ready to capture the
+     geometry with [[begin-raw]]."
      [mode]
      (let [mode (u/resolve-constant-key mode text-modes)]
        (.textMode (current-graphics) (int mode)))))
@@ -4209,7 +4213,7 @@
     :added "1.0"}
   text-size
   "Sets the current font size. This size will be used in all
-  subsequent calls to the text fn. Font size is measured in
+  subsequent calls to the [[text]] function. Font size is measured in
   units of pixels."
   [size]
   (.textSize (current-graphics) (float size)))
@@ -4222,8 +4226,8 @@
        :subcategory "Attributes"
        :added "2.8.0"}
      text-style
-     "Sets/gets the style of the text for system fonts to :normal, :italic,
-     or :bold. Note: this may be is overridden by CSS styling. For
+     "Sets/gets the style of the text for system fonts to `:normal`, `:italic`,
+     or `:bold`. Note: this may be is overridden by CSS styling. For
      non-system fonts (opentype, truetype, etc.) please load styled fonts
      instead."
      [style]
@@ -4237,12 +4241,12 @@
     :subcategory "Vertex"
     :added "1.0"}
   texture
-  "Sets a texture to be applied to vertex points. The texture fn must
-  be called between begin-shape and end-shape and before any calls to
-  vertex.
+  "Sets a texture to be applied to vertex points. The [[texture]] function must
+  be called between [[begin-shape]] and [[end-shape]] and before any calls to
+  [[vertex]].
 
   When textures are in use, the fill color is ignored. Instead, use
-  tint to specify the color of the texture as it is applied to the
+  [[tint]] to specify the color of the texture as it is applied to the
   shape."
   #?(:clj [^PImage img]
      :cljs [img])
@@ -4257,14 +4261,14 @@
        :added "1.0"}
      texture-mode
      "Sets the coordinate space for texture mapping. There are two
-  options, :image and :normal.
+  options, `:image` and `:normal`.
 
-  :image refers to the actual coordinates of the image and :normal
+  `:image` refers to the actual coordinates of the image and `:normal`
   refers to a normalized space of values ranging from 0 to 1. The
-  default mode is :image. In :image, if an image is 100 x 200 pixels,
+  default `mode` is `:image`. In `:image`, if an image is 100 x 200 pixels,
   mapping the image onto the entire size of a quad would require the
-  points (0,0) (0,100) (100,200) (0,200). The same mapping in
-  NORMAL_SPACE is (0,0) (0,1) (1,1) (0,1)."
+  points `(0,0) (0,100) (100,200) (0,200)`. The same mapping in
+  NORMAL_SPACE is `(0,0) (0,1) (1,1) (0,1)`."
      [mode]
      (let [mode (u/resolve-constant-key mode texture-modes)]
        (.textureMode (current-graphics) (int mode)))))
@@ -4278,8 +4282,8 @@
        :added "2.0"}
      texture-wrap
      "Defines if textures repeat or draw once within a texture map. The two
-  parameters are :clamp (the default behavior) and :repeat. This function
-  only works with the :p2d and :p3d renderers."
+  parameters are `:clamp` (the default behavior) and `:repeat`. This function
+  only works with the `:p2d` and `:p3d` renderers."
      [mode]
      (let [mode (u/resolve-constant-key mode texture-wrap-modes)]
        (.textureWrap (current-graphics) mode))))
@@ -4303,15 +4307,15 @@
     :added "1.0"}
   tint
   "Sets the fill value for displaying images. Images can be tinted to
-  specified colors or made transparent by setting the alpha.
+  specified colors or made transparent by setting the `alpha`.
 
   To make an image transparent, but not change it's color, use white
-  as the tint color and specify an alpha value. For instance,
-  tint(255, 128) will make an image 50% transparent (unless
-  colorMode() has been used).
+  as the tint color and specify an `alpha` value. For instance,
+  `(tint 255 128)` will make an image 50% transparent (unless
+  [[color-mode]] has been used).
 
   The value for the parameter gray must be less than or equal to the
-  current maximum value as specified by colorMode(). The default
+  current maximum value as specified by [[color-mode]]. The default
   maximum value is 255.
 
   Also used to control the coloring of textures in 3D."
@@ -4328,10 +4332,11 @@
        :subcategory "3D Primitives"
        :added "3.0.0"}
      torus
-     "Draw a torus with given radius and tube radius.
+     "Draw a torus with given `radius` and `tube-radius`.
+
       Optional parameters:
-        detail-x: number of segments, the more segments the smoother geometry default is 24
-        detail-y: number of segments, the more segments the smoother geometry default is 16"
+        * `detail-x` - number of segments, the more segments the smoother geometry default is 24
+        * `detail-y` - number of segments, the more segments the smoother geometry default is 16"
      ([radius tube-radius]
       (.torus (current-graphics) (float radius) (float tube-radius)))
      ([radius tube-radius detail-x]
@@ -4347,15 +4352,15 @@
     :added "1.0"}
   translate
   "Specifies an amount to displace objects within the display
-  window. The x parameter specifies left/right translation, the y
-  parameter specifies up/down translation, and the z parameter
+  window. The `tx` parameter specifies left/right translation, the `ty`
+  parameter specifies up/down translation, and the `tz` parameter
   specifies translations toward/away from the screen.  Transformations
   apply to everything that happens after and subsequent calls to the
-  function accumulates the effect. For example, calling (translate 50
-  0) and then (translate 20, 0) is the same as (translate 70, 0). If
-  translate is called within draw, the transformation is reset when
+  function accumulates the effect. For example, calling `(translate 50
+  0)` and then `(translate 20, 0)` is the same as `(translate 70, 0)`. If
+  [[translate]] is called within draw, the transformation is reset when
   the loop begins again. This function can be further controlled by
-  the push-matrix and pop-matrix."
+  the [[push-matrix]] and [[pop-matrix]] functions."
   ([v] (apply translate v))
   ([tx ty] (.translate (current-graphics) (float tx) (float ty)))
   ([tx ty tz] (.translate (current-graphics) (float tx) (float ty) (float tz))))
@@ -4384,7 +4389,7 @@
     :subcategory "Conversion"
     :added "1.0"}
   unbinary
-  "Unpack a binary string to an integer. See binary for converting
+  "Unpack a binary string to an integer. See [[binary]] for converting
   integers to strings."
   [str-val]
   #?(:clj (PApplet/unbinary (str str-val))
@@ -4410,14 +4415,14 @@
     :added "1.0"}
   update-pixels
   "Updates the display window or image with the data in the pixels array.
-  Use in conjunction with (pixels). If you're only reading pixels from
-  the array, there's no need to call update-pixels unless there are
+  Use in conjunction with [[pixels]]. If you're only reading pixels from
+  the array, there's no need to call [[update-pixels]] unless there are
   changes.
 
-  Certain renderers may or may not seem to require pixels or
-  update-pixels. However, the rule is that any time you want to
-  manipulate the pixels array, you must first call pixels, and
-  after changes have been made, call update-pixels. Even if the
+  Certain renderers may or may not seem to require [[pixels]] or
+  [[update-pixels]]. However, the rule is that any time you want to
+  manipulate the `pixels` array, you must first call [[pixels]], and
+  after changes have been made, call [[update-pixels]]. Even if the
   renderer may not seem to use this function in the current Processing
   release, this will always be subject to change."
   ([] (update-pixels (current-graphics)))
@@ -4431,19 +4436,19 @@
     :added "1.0"}
   vertex
   "All shapes are constructed by connecting a series of
-  vertices. vertex is used to specify the vertex coordinates for
+  vertices. [[vertex]] is used to specify the vertex coordinates for
   points, lines, triangles, quads, and polygons and is used
-  exclusively within the begin-shape and end-shape fns.
+  exclusively within the [[begin-shape]] and [[end-shape]] functions.
 
-  Drawing a vertex in 3D using the z parameter requires the :p3d or
-  :opengl renderers to be used.
+  Drawing a vertex in 3D using the `z` parameter requires the `:p3d` or
+  `:opengl` renderers to be used.
 
   This function is also used to map a texture onto the geometry. The
-  texture fn declares the texture to apply to the geometry and the u
-  and v coordinates set define the mapping of this texture to the
-  form. By default, the coordinates used for u and v are specified in
+  [[texture]] function declares the texture to apply to the geometry and the `u`
+  and `v` coordinates set define the mapping of this texture to the
+  form. By default, the coordinates used for `u` and `v` are specified in
   relation to the image's size in pixels, but this relation can be
-  changed with texture-mode."
+  changed with [[texture-mode]]."
   ([x y] (.vertex (current-graphics) (float x) (float y)))
   ([x y z] (.vertex (current-graphics) (float x) (float y) (float z)))
   ([x y u v] #?(:clj (.vertex (current-graphics) (float x) (float y) (float u) (float v))
@@ -4484,13 +4489,17 @@
     :added "1.7"}
   with-fill
   "Temporarily set the fill color for the body of this macro.
-   The code outside of with-fill form will have the previous fill color set.
+   The code outside of the [[with-fill]] form will have the previous
+   fill color set.
 
    A fill argument of nil disables the fill.
 
-   Example: (with-fill 255 ...)
-            (with-fill [10 80 98] ...)
-            (with-fill nil ...)"
+   Examples:
+   ```
+   (with-fill 255 ...)
+   (with-fill [10 80 98] ...)
+   (with-fill nil ...)
+   ```"
   [fill & body]
   `(let [fill# ~fill
          previous-fill# (quil.core/current-fill)]
@@ -4513,13 +4522,17 @@
     :added "1.7"}
   with-stroke
   "Temporarily set the stroke color for the body of this macro.
-   The code outside of with-stroke form will have the previous stroke color set.
+   The code outside of the [[with-stroke]] form will have the previous
+   stroke color set.
 
    A stroke argument of nil disables the stroke.
 
-   Example: (with-stroke 255 ...)
-            (with-stroke [10 80 98] ...)
-            (with-stroke nil ...)"
+   Examples:
+   ```
+   (with-stroke 255 ...)
+   (with-stroke [10 80 98] ...)
+   (with-stroke nil ...)
+   ```"
   [stroke & body]
   `(let [stroke# ~stroke
          previous-stroke# (quil.core/current-stroke)]
@@ -4560,16 +4573,18 @@
     :added "1.0"}
   with-rotation
   "Performs body with rotation, restores current transformation on exit.
-  Accepts a vector [angle] or [angle x y z].
+  Accepts a vector `[angle]` or `[angle x y z]`.
 
   When 4 arguments provides it produces a rotation of angle degrees
-  around the vector x y z. Check examples for to better understand.
+  around the vector x y z. Check examples to better understand.
   This rotation follows the right-hand rule, so if the vector x y z points
   toward the user, the rotation will be counterclockwise.
 
   Example:
+  ```
     (with-rotation [angle]
-      (vertex 1 2))"
+      (vertex 1 2))
+  ```"
   [rotation & body]
   `(let [tr# ~rotation]
      (quil.core/push-matrix)
@@ -4592,7 +4607,7 @@
     :added "1.7"}
   with-graphics
   "All subsequent calls of any drawing function will draw on given
-  graphics. 'with-graphics' cannot be nested (you can draw simultaneously
+  graphics. [[with-graphics]] cannot be nested (you can draw simultaneously
   only on 1 graphics)"
   [graphics & body]
   `(let [^PGraphics gr# ~graphics]
@@ -4607,7 +4622,7 @@
         :added "1.0"}
   sketch
   "Create and start a new visualisation applet. Can be used to create
-  new sketches programmatically. See documentation for 'defsketch' for
+  new sketches programmatically. See documentation for [[defsketch]] for
   list of available options."
   [& opts]
   #?(:clj (apply ap/applet opts)
@@ -4619,142 +4634,101 @@
             :added "1.0"}
   defsketch
   "Define and start a sketch and bind it to a var with the symbol
-  app-name. If any of the options to the various callbacks are
+  `app-name`. If any of the options to the various callbacks are
   symbols, it wraps them in a call to var to ensure they aren't
-  inlined and that redefinitions to the original fns are reflected in
+  inlined and that redefinitions to the original functions are reflected in
   the visualisation.
 
-  Available options:
-
-   :size           - A vector of width and height for the sketch or :fullscreen.
-                     Defaults to [500 300]. If you're using :fullscreen you may
-                     want to enable present mode - :features [:present].
-                     :fullscreen size works only in Clojure. In ClojureScript
-                     all sketches are support fullscreen when you press F11.
-
-   :renderer       - Specifies the renderer type. One of :p2d, :p3d, :java2d,
-                     :opengl, :pdf, :svg). Defaults to :java2d. :dxf renderer
-                     can't be used as sketch renderer. Use begin-raw method
-                     instead. In clojurescript only :p2d and :p3d renderers
-                     are supported.
-
-   :output-file    - Specifies an output file path. Only used in :pdf and :svg
-                     modes. Not supported in clojurescript. When writing to a
-                     file, call `(q/exit)` at the end of the draw call to end
-                     the sketch and not write repeatedly to the file.
-
-   :title          - A string which will be displayed at the top of
-                     the sketch window. Not supported in clojurescript.
-
-   :features       - A vector of keywords customizing sketch behaviour.
-                     Supported features:
-
-                     :keep-on-top - Sketch window will always be above other
-                                    windows. Note: some platforms might not
-                                    support always-on-top windows.
-                                    Not supported in clojurescript.
-
-                     :exit-on-close - Shutdown JVM  when sketch is closed.
-                                      Not supported in clojurescript.
-
-                     :resizable - Makes sketch resizable.
-                                  Not supported in clojurescript.
-
-                     :no-safe-fns - Do not catch and print exceptions thrown
-                                    inside functions provided to sketch (like
-                                    draw, mouse-click, key-pressed and
-                                    other). By default all exceptions thrown
-                                    inside these functions are caught. This
-                                    prevents sketch from breaking when bad
-                                    function was provided and allows you to
-                                    fix it and reload it on fly. You can
-                                    disable this behaviour by enabling
-                                    :no-safe-fns feature.
-                                    Not supported in clojurescript.
-
-                     :present - Switch to present mode (fullscreen without
-                                borders, OS panels). You may want to use
-                                this feature together with :size :fullscreen.
-                                Not supported in ClojureScript. In ClojureScript
-                                fullscreen is enabled by pressing F11 and it's
-                                enabled on all sketches automatically.
-
-                     :no-start - Disables autostart if sketch was created using
-                                 defsketch macro. To start sketch you have to
-                                 call function created defsketch.
-                                 Supported only in ClojureScript.
-
-                     Usage example: :features [:keep-on-top :present]
-
-   :bgcolor        - Sets background color for unused space in present mode.
-                     Color is specified in hex format: #XXXXXX.
-                     Example: :bgcolor \"#00FFFF\" (cyan background)
-                     Not supported in ClojureScript.
-
-   :display        - Sets what display should be used by this sketch.
-                     Displays are numbered starting from 0. Example: :display 1.
-                     Not supported in ClojureScript.
-
-   :setup          - A function to be called once when setting the sketch up.
-
-   :draw           - A function to be repeatedly called at most n times per
-                     second where n is the target frame-rate set for
-                     the visualisation.
-
-   :host           - String id of canvas element or DOM element itself.
-                     Specifies host for the sketch. Must be specified in sketch,
-                     may be omitted in defsketch. If omitted in defsketch,
-                     :host is set to the name of the sketch. If element with
-                     specified id is not found on the page and page is empty -
-                     new canvas element will be created. Used in ClojureScript.
-
-   :focus-gained   - Called when the sketch gains focus.
-                     Not supported in ClojureScript.
-
-   :focus-lost     - Called when the sketch loses focus.
-                     Not supported in ClojureScript.
-
-   :mouse-entered  - Called when the mouse enters the sketch window.
-
-   :mouse-exited   - Called when the mouse leaves the sketch window
-
-   :mouse-pressed  - Called every time a mouse button is pressed.
-
-   :mouse-released - Called every time a mouse button is released.
-
-   :mouse-clicked  - called once after a mouse button has been pressed
-                     and then released.
-
-   :mouse-moved    - Called every time the mouse moves and a button is
-                     not pressed.
-
-   :mouse-dragged  - Called every time the mouse moves and a button is
-                     pressed.
-
-   :mouse-wheel    - Called every time mouse wheel is rotated.
-                     Takes 1 argument - wheel rotation, an int.
-                     Negative values if the mouse wheel was rotated
-                     up/away from the user, and positive values
-                     if the mouse wheel was rotated down/ towards the user
-
-   :key-pressed    - Called every time any key is pressed.
-
-   :key-released   - Called every time any key is released.
-
-   :key-typed      - Called once every time non-modifier keys are
-                     pressed.
-
-   :on-close       - Called once, when sketch is closed
-                     Not supported in ClojureScript.
-
-   :middleware     - Vector of middleware to be applied to the sketch.
-                     Middleware will be applied in the same order as in comp
-                     function: [f g] will be applied as (f (g options)).
-
-   :settings       - cousin of :setup. A function to be called once when
-                     setting sketch up. Should be used only for (smooth) and
-                     (no-smooth). Due to Processing limitations these functions
-                     cannot be used neither in :setup nor in :draw."
+  * `:size`           - A vector of width and height for the sketch or :fullscreen.
+                        Defaults to `[500 300]`. If you're using :fullscreen you may
+                        want to enable present mode - :features [:present].
+                        :fullscreen size works only in Clojure. In ClojureScript
+                        all sketches are support fullscreen when you press F11.
+  * `:renderer`       - Specifies the renderer type. One of `:p2d`, `:p3d`, `:java2d`,
+                        `:opengl`, `:pdf`, `:svg`). Defaults to `:java2d`. `:dxf` renderer
+                        can't be used as sketch renderer. Use [[begin-raw]] method
+                        instead. In clojurescript only `:p2d` and `:p3d` renderers
+                        are supported.
+  * `:output-file`    - Specifies an output file path. Only used in `:pdf` and `:svg`
+                        modes. Not supported in clojurescript. When writing to a
+                        file, call [[exit]] at the end of the draw call to end
+                        the sketch and not write repeatedly to the file.
+  * `:title`          - A string which will be displayed at the top of
+                        the sketch window. Not supported in clojurescript.
+  * `:features`       - A vector of keywords customizing sketch behaviour.
+                        Supported features:
+    - `:keep-on-top`   - Sketch window will always be above other windows.
+                         Note: some platforms might not support always-on-top windows.
+                         Not supported in clojurescript.
+    - `:exit-on-close` - Shutdown JVM  when sketch is closed.
+                         Not supported in clojurescript.
+    - `:resizable`     - Makes sketch resizable. Not supported in clojurescript.
+    - `:no-safe-fns`   - Do not catch and print exceptions thrown inside functions
+                         provided to sketch (like draw, [[mouse-click]],
+                         [[key-pressed]] and others). By default all exceptions
+                         thrown inside these functions are caught. This prevents
+                         sketch from breaking when bad function was provided and
+                         allows you to fix it and reload it on fly. You can
+                         disable this behaviour by enabling `:no-safe-fns`
+                         feature. Not supported in clojurescript.
+    - `:present`       - Switch to present mode (fullscreen without borders, OS
+                         panels). You may want to use this feature together with
+                         `:size :fullscreen`. Not supported in ClojureScript. In
+                         ClojureScript fullscreen is enabled by pressing F11 and
+                         it's enabled on all sketches automatically.
+    - `:no-start`      - Disables autostart if sketch was created using defsketch
+                         macro. To start sketch you have to call function created
+                         defsketch. Supported only in ClojureScript.
+                        Usage example: `:features [:keep-on-top :present]`
+  * `:bgcolor`        - Sets background color for unused space in present mode.
+                        Color is specified in hex format for example
+                        `:bgcolor \"#00FFFF\"` (cyan background)
+                        Not supported in ClojureScript.
+  * `:display`        - Sets what display should be used by this sketch.
+                        Displays are numbered starting from 0. Example: `:display 1`.
+                        Not supported in ClojureScript.
+  * `:setup`          - A function to be called once when setting the sketch up.
+  * `:draw`           - A function to be repeatedly called at most n times per
+                        second where n is the target [[frame-rate]] set for
+                        the visualisation.
+  * `:host`           - String id of canvas element or DOM element itself.
+                        Specifies host for the sketch. Must be specified in sketch,
+                        may be omitted in defsketch. If omitted in defsketch,
+                        :host is set to the name of the sketch. If element with
+                        specified id is not found on the page and page is empty -
+                        new canvas element will be created. Used in ClojureScript.
+  * `:focus-gained`   - Called when the sketch gains focus.
+                        Not supported in ClojureScript.
+  * `:focus-lost`     - Called when the sketch loses focus.
+                        Not supported in ClojureScript.
+  * `:mouse-entered`  - Called when the mouse enters the sketch window.
+  * `:mouse-exited`   - Called when the mouse leaves the sketch window
+  * `:mouse-pressed`  - Called every time a mouse button is pressed.
+  * `:mouse-released` - Called every time a mouse button is released.
+  * `:mouse-clicked`  - Called once after a mouse button has been pressed
+                        and then released.
+  * `:mouse-moved`    - Called every time the mouse moves and a button is
+                        not pressed.
+  * `:mouse-dragged`  - Called every time the mouse moves and a button is
+                        pressed.
+  * `:mouse-wheel`    - Called every time mouse wheel is rotated.
+                        Takes 1 argument - wheel rotation, an int.
+                        Negative values if the mouse wheel was rotated
+                        up/away from the user, and positive values
+                        if the mouse wheel was rotated down/ towards the user
+  * `:key-pressed`    - Called every time any key is pressed.
+  * `:key-released`   - Called every time any key is released.
+  * `:key-typed`      - Called once every time non-modifier keys are
+                        pressed.
+  * `:on-close`       - Called once, when sketch is closed.
+                        Not supported in ClojureScript.
+  * `:middleware`     - Vector of middleware to be applied to the sketch.
+                        Middleware will be applied in the same order as in comp
+                        function: [f g] will be applied as `(f (g options))`.
+  * `:settings`       - Cousin of `:setup`. A function to be called once when
+                        setting sketch up. Should be used only for [[smooth]] and
+                        [[no-smooth]]. Due to Processing limitations these functions
+                        cannot be used neither in `:setup` nor in `:draw`."
   [app-name & options]
   #?(:clj
      (if (u/clj-compilation?)
@@ -4769,9 +4743,9 @@
         :subcategory "Keyboard"
         :added "1.6"}
   key-coded?
-  "Returns true if char c is a 'coded' char i.e. it is necessary to
-  fetch the key-code as an integer and use that to determine the
-  specific key pressed. See key-keyword."
+  "Returns true if char `c` is a `coded` char i.e. it is necessary to
+  fetch the [[key-code]] as an integer and use that to determine the
+  specific key pressed. See [[key-as-keyword]]."
   [c]
   #?(:clj (= PConstants/CODED (int c))
      ; See https://github.com/google/closure-compiler/issues/1676
@@ -4784,8 +4758,8 @@
         :added "1.6"}
   key-as-keyword
   "Returns a keyword representing the currently pressed key. Modifier
-  keys are represented as: :up, :down, :left, :right, :alt, :control,
-  :shift, :command, :f1-24"
+  keys are represented as: `:up`, `:down`, `:left`, `:right`, `:alt`, `:control`,
+  `:shift`, `:command`, `:f1-24`"
   []
   (let [key-char (raw-key)
         code     (key-code)]
@@ -4805,8 +4779,8 @@
        :category "Debugging"
        :added "1.6"}
      debug
-     "Prints msg and then sleeps the current thread for delay-ms. Useful
-  for debugging live running sketches. delay-ms defaults to 300. "
+     "Prints `msg` and then sleeps the current thread for `delay-ms`. Useful
+  for debugging live running sketches. `delay-ms` defaults to 300. "
      ([msg] (debug msg 300))
      ([msg delay-ms]
       (println msg)
@@ -4834,7 +4808,7 @@
 #?(:clj
    (defn show-fns
      "If given a number, print all the functions within category or
-  subcategory specified by the category index (use show-cats to see a
+  subcategory specified by the category index (use [[show-cats]] to see a
   list of index nums).
 
   If given a string or a regular expression, print all the functions


### PR DESCRIPTION
Updated rest of core docs with markdown. Also touched on some other namespaces but I think it's better to merge them later because I don't want this to hold back release too much and core is the most important anyway.

Regarding renderer for quil site I tried first using [markdown-clj](https://github.com/yogthos/markdown-clj) directly in quil-site project [here](https://github.com/quil/quil-site/blob/master/src/clj/quil_site/views/api.clj#L199). It worked but the html output was not very good. Then took a look into the [cljdoc sources](https://github.com/cljdoc/cljdoc/blob/master/src/cljdoc/render/rich_text.clj#L60) and found they are using the flexmark-java library. Added that (again in quil-site) but then thought perhaps it's better to add it in quil docs utils because it's enough for conversion to happen once. You can see how docs would look like in [this pull request](https://github.com/quil/quil-site/pull/27).

The code I added is lifted directly from cljdoc with minor changes. The only issue I still have is that the links don't work. I think for links on the same page it should be easy but I'm not sure how best to adapt this so that links to a different function category and/or namespace work. Wanted to check about approach before investing more time. What do you think?