### PR TITLE
fix exception on exit when the applet has no window

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject quil "3.1.0"
+(defproject quil "3.1.1-SNAPSHOT"
   :description "(mix Processing Clojure)"
   :url "http://github.com/quil/quil"
 

--- a/src/clj/quil/applet.clj
+++ b/src/clj/quil/applet.clj
@@ -31,7 +31,7 @@
   the JVM is closed as well which is not the case for clojure. So here we're
   performing renderer-specific cleanups."
   [applet]
-  (let [native (-> applet .getSurface .getNative)]
+  (if-let [native (-> applet .getSurface .getNative)]
     (condp = (.getClass native)
 
       com.jogamp.newt.opengl.GLWindow


### PR DESCRIPTION
Fixes #325

This small patch to `destroy-window` avoids a null pointer exception
when there is no native window object associated with the applet
(which can occur when rendering to pdf).