### PR TITLE
upgrade to processing 4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject quil "3.1.1-SNAPSHOT"
+(defproject quil "4.0.0-SNAPSHOT-1"
   :description "(mix Processing Clojure)"
   :url "http://github.com/quil/quil"
 
@@ -10,12 +10,12 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [quil/processing-core "3.5.3"]
+                 [quil/processing-core "4.0.0-alpha-2"]
                  [quil/processing-pdf "3.5.3"]
                  [quil/processing-dxf "3.5.3"]
                  [quil/processing-svg "3.5.3"]
-                 [quil/jogl-all-fat "2.3.2"]
-                 [quil/gluegen-rt-fat "2.3.2"]
+                 [quil/jogl-all-fat "2.4.0-RC"]
+                 [quil/gluegen-rt-fat "2.4.0-RC"]
                  [cljsjs/p5 "0.9.0-0"]
                  [com.lowagie/itext "2.1.7"
                   :exclusions [bouncycastle/bctsp-jdk14]]

--- a/src/clj/quil/applet.clj
+++ b/src/clj/quil/applet.clj
@@ -66,7 +66,6 @@
   (let [m              (meta applet)
         keep-on-top?   (:keep-on-top m)
         surface        (.getSurface applet)
-        frame          (.frame applet)
         resizable?     (:resizable m)]
     ; TODO: check if resizable and alwaysOnTop work correctly.
     (javax.swing.SwingUtilities/invokeLater


### PR DESCRIPTION
here is a start for getting processing 4 working.

Currently default rendering mode works, also OPENGL. with P2D and P3D sometimes there is no output in the window but can save the correctly rendered image.
I'll look into it next week could be a processing issue

getting the gluegen and jogl jars is bit tricky as they are still [release candidate](https://jogamp.org/deployment/v2.4.0-rc-20200113/jar/)
I have attached appropriately packaged fat jars [processing-4-jars.zip](https://github.com/quil/quil/files/5400072/processing-4-jars.zip)


