### PR TITLE
one error spits one log

### DIFF
--- a/src/clj/quil/middlewares/safe_fns.clj
+++ b/src/clj/quil/middlewares/safe_fns.clj
@@ -3,12 +3,16 @@
             [quil.util :as u]))
 
 (defn- wrap-fn [name function]
-  (fn []
-    (try
-      (function)
-      (catch Exception e
-        (println "Exception in " name " function: " e "\nstacktrace: " (with-out-str (print-cause-trace e)))
-        (Thread/sleep 1000)))))
+  (let [save_ex (atom nil)]
+    (fn []
+      (try
+        (function)
+        (catch Exception e
+          (let [errstr (str e)]
+          (when-not (= @save_ex errstr)
+            (println "Exception in " name " function: " e "\nstacktrace: " (with-out-str (print-cause-trace e)))
+            (reset! save_ex errstr))
+          (Thread/sleep 1000)   ))))))
 
 (defn- wrap-mouse-wheel [function]
   (fn [rotation]


### PR DESCRIPTION
Hello, I love quil, your great work.

This wrap-fn flooded a repl console with duplicating error logs because it spited it out every 1 seconds.
Wrapping an error in a closure and comparing another error with this (whether it would be the same) is an solution.

the test is done that "lein test :only quil.middlewares.safe-fns-test".

Thank you.