### PR TITLE
Added :mouse-buttons option to navigation-2d

### DIFF
--- a/src/cljc/quil/middleware.cljc
+++ b/src/cljc/quil/middleware.cljc
@@ -124,6 +124,11 @@
 
   * `:zoom` - number indicating current zoom level. Default is `1`.
 
+  * `:mouse-buttons` - set containing zero or more of the keys `:left`,
+                       `:right`, and `center` indicating which mouse buttons
+                       are used for panning the screen. Default is
+                       `#{:left :right :center}`.
+
   Accessing position information from a sketch
 
   [[navigation-2d]] uses [[fun-mode]] under the hood so all position-related

--- a/src/cljc/quil/middlewares/navigation_2d.cljc
+++ b/src/cljc/quil/middlewares/navigation_2d.cljc
@@ -19,14 +19,15 @@
   []
   {:position [(/ (q/width) 2.0)
               (/ (q/height) 2.0)]
-   :zoom 1})
+   :zoom 1
+   :mouse-buttons #{:left :right :center}})
 
 (defn- setup-2d-nav
   "Custom 'setup' function which creates initial position
   configuration and puts it to the state map."
   [user-setup user-settings]
   (let [initial-state (-> user-settings
-                          (select-keys [:position :zoom])
+                          (select-keys [:position :zoom :mouse-buttons])
                           (->> (merge (default-position))))]
     (update-in (user-setup) [:navigation-2d]
                #(merge initial-state %))))
@@ -36,12 +37,15 @@
   zoom into account as well."
   [state event]
   (assert-state-has-navigation state)
-  (let [dx (- (:p-x event) (:x event))
-        dy (- (:p-y event) (:y event))
-        zoom (-> state :navigation-2d :zoom)]
-    (-> state
-        (update-in [:navigation-2d :position 0] + (/ dx zoom))
-        (update-in [:navigation-2d :position 1] + (/ dy zoom)))))
+  (let [mouse-buttons (-> state :navigation-2d :mouse-buttons)]
+    (if (contains? mouse-buttons (:button event))
+      (let [dx (- (:p-x event) (:x event))
+            dy (- (:p-y event) (:y event))
+            zoom (-> state :navigation-2d :zoom)]
+        (-> state
+            (update-in [:navigation-2d :position 0] + (/ dx zoom))
+            (update-in [:navigation-2d :position 1] + (/ dy zoom))))
+      state)))
 
 (defn- mouse-wheel
   "Changes zoom settings based on scroll."


### PR DESCRIPTION
I'm not able to use navigation-2d as it is in my project because it interferes with the `mouse-dragged` function in my sketch. My sketch uses `mouse-dragged` to let the user click and drag things around the screen, but with navigation-2d enabled, nothing can be moved without simultaneously panning around the screen. 

So I added a `:mouse-buttons` key to the navigation-2d settings map that allows you to control which mouse buttons are used for navigation. The value of `:mouse-buttons` should be a subset of `#{:left :right :center}` and only the mouse buttons in that subset can be used for panning.

For example, in `defsketch` the user could put `:navigation-2d {:mouse-buttons #{:center}}` in order to use center-click for navigation while leaving left-click free for other interaction.