### PR TITLE
Exclude abs to override cljs.core or clojure.core

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Basic Github Actions test harness for existing `lein test` on Linux [#381](https://github.com/quil/quil/pull/381)
+* Fix for `#cljs.core/abs` compile warning [#380](https://github.com/quil/quil/pull/380)
 
 ## 3.1.0
 __13th October 2019_

--- a/src/cljc/quil/core.cljc
+++ b/src/cljc/quil/core.cljc
@@ -1,5 +1,6 @@
 (ns ^{:doc "Wrappers and extensions around the core Processing.org API."}
  quil.core
+  (:refer-clojure :exclude [abs])
   #?(:clj
      (:import [processing.core PApplet PImage PGraphics PFont PConstants PShape]
               [processing.opengl PShader]


### PR DESCRIPTION
This should address issue #374, allowing quil.core to compile without warnings in cljs.