### PR TITLE
Basic GitHub Actions test harness

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,49 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-leiningen:
+    name: Test Leiningen
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@11.0
+        with:
+          lein: 2.9.8
+
+      - name: Cache Leiningen dependencies
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-maven
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/project.clj') }}
+          restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
+
+      - name: Leiningen Install
+        run: lein install
+
+      - name: Version
+        run: lein version
+
+      - name: Leiningen Test
+        run: lein test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,4 +46,6 @@ jobs:
         run: lein version
 
       - name: Leiningen Test
-        run: lein test
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: lein test


### PR DESCRIPTION
This just runs the existing tests using `lein test` inside of xvfb environment on ubuntu. While the tests currently report as passing, looking through the log of each test, there are some errors reported that should be investigated.

The matrix build is enabled to attempt windows and macOS builds, but both are failing. The Windows build is failing in the checkout action, so will need to look upstream for that. The macOS build is making it all the way to lein test, but looks to be throwing some errors attempting to make graphic calls to a dynamic library from java 8. It's possible there is a workaround, but this may depend on upgrading from java 8, which is blocked on upstream processing/opengl problems for now.