### PR TITLE
P5js 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ screen-*.tif
 .ds_store
 dev-resources/snippet-snapshots/**/*-actual.png
 dev-resources/snippet-snapshots/**/*-difference.png
+/libraries/

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :tasks
+ {:requires ([bb.processing :as processing])
+  processing-install
+  {:docs "install processing jars"
+   :task (processing/install)}}}

--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,10 @@
 
         ;; svg export
         org.apache.xmlgraphics/batik-svggen {:local/root "libraries/batik.jar"}
-        org.apache.xmlgraphics/batik-dom {:local/root "libraries/batik.jar"}}
+        org.apache.xmlgraphics/batik-dom {:local/root "libraries/batik.jar"}
+
+        ;; clojurescript p5js
+        cljsjs/p5 {:mvn/version "1.7.0-0"}}
  :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}}
                    :ns-default build}
            ;; not picking up all test namespaces, probably has to do with :pattern

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [quil/processing-svg "3.5.3"]
                  [quil/jogl-all-fat "2.3.2"]
                  [quil/gluegen-rt-fat "2.3.2"]
-                 [cljsjs/p5 "0.9.0-0"]
+                 [cljsjs/p5 "1.7.0-0"]
                  [com.lowagie/itext "2.1.7"
                   :exclusions [bouncycastle/bctsp-jdk14]]
                  [org.bouncycastle/bctsp-jdk14 "1.38"]

--- a/src/bb/processing.clj
+++ b/src/bb/processing.clj
@@ -1,0 +1,28 @@
+(ns bb.processing
+  (:require
+   [clojure.java.io :as io]
+   [babashka.fs :as fs]
+   [babashka.process :as bp]
+   [babashka.http-client :as http]))
+
+;; linux only for now
+(defn install []
+  (let [url "https://github.com/processing/processing4/releases/download/processing-1293-4.3/processing-4.3-linux-x64.tgz"]
+    (println "Downloading processing4 ...")
+    (io/copy (:body (http/get url {:as :stream}))
+             (io/file "processing.jar"))
+
+    (println "unpacking ...")
+    (bp/shell "tar" "-zxf" "processing.jar")
+
+    (fs/create-dirs "libraries")
+    ;; core.jar, jogl-all.jar, gluegen-rt.jar
+    (fs/copy-tree "processing-4.3/core/library" "libraries" {:replace-existing true})
+    (fs/copy "processing-4.3/modes/java/libraries/dxf/library/dxf.jar" "libraries" {:replace-existing true})
+    ;; pdf.jar, itext.jar
+    (fs/copy-tree "processing-4.3/modes/java/libraries/pdf/library/" "libraries" {:replace-existing true})
+    ;; svg.jar, batik.jar
+    (fs/copy-tree "processing-4.3/modes/java/libraries/svg/library/" "libraries" {:replace-existing true})
+
+    (fs/delete-tree "processing-4.3")
+    (fs/delete "processing.jar")))

--- a/src/bb/processing.clj
+++ b/src/bb/processing.clj
@@ -26,3 +26,10 @@
 
     (fs/delete-tree "processing-4.3")
     (fs/delete "processing.jar")))
+
+;; clj -T:build release caused:
+;; Execution error (UnsupportedClassVersionError) at java.lang.ClassLoader/defineClass1 (ClassLoader.java:-2).
+;; processing/core/PApplet has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
+;; jdk11 is too old to process class file version, so using 17 instead:
+;; $ sudo apt install openjdk-17-jdk
+;; $ sudo update-java-alternatives -s java-1.17.0-openjdk-amd64


### PR DESCRIPTION
Upgrades p5js dependency to 1.7.0 and incorporates a build script for downloading processing jars for build on linux.

Linux test procedure thus far:

```
bb processing-install # downloads processing jars for linux
clj -T:build release # generates a jar file in target/
```

copied the jar file into a project I have with tons of quil sketches using p5js and deleted my npm deps for p5 and replaced my quil dependency with the local jar generated in the step above. I did a cursory check through some sketches and while I encountered some difference in the couple sketches using 3d rendering, everything appeared to be working there. I suspect the 3d rendering issues are from the p51.7 upgrade and not an integration problem.

I also ran the project tests using:

```
lein with-profile cljs-testing do cljsbuild once tests, ring server
```

Many of the semi-automated cljs tests looked like they were passing, and actually had a higher resolution then the expected output from before. This is from manual inspection, it's not clear if this bitrot or otherwise but the test framework is not report success rate, but by manually inspecting test output I can get a sense on success rate.

There were a few problems that I noticed. It looks like there are issues with full screen and rescaling under the manual tests. I suspect this is due to upstream p5js implementing better support for HiDPI displays in the past couple years, but as a result several of the examples were clipped to the upper left corner of the generated image (either before or after rescale). Another set of problems is around create-image/resize-image/mask-image/set-image. The expected image has a gradient and the new output is just a black square so will need to investigate that. On other hand load-image was working under the new build instead of an empty value for the expected under the old. There are definite discrepancies in the 3d tests, not for translation or rotation, but for material tests like specular and shininess though I'm not certain the expected values are correct, so these might be an improvement.

So certainly some discrepancies in the test cases, but making progress.

