### PR TITLE
Automated test harness for CLJ and CLJS sketches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: clj-${{ runner.os }}-${{ hashFiles('**/project.clj') }}
-          restore-keys: clj-${{ runner.os }}-
+          key: lein-${{ runner.os }}-${{ hashFiles('**/project.clj') }}
+          restore-keys: lein-${{ runner.os }}-
 
       - name: Leiningen Install
         run: lein install
@@ -98,5 +98,53 @@ jobs:
         uses: coactions/setup-xvfb@v1
         with:
           run: clojure -Mfig:cljs-test
-      
+
+  test-clj:
+    name: Test Clojure
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cache deps.edn dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: clj-${{ runner.os }}-${{ hashFiles('**/deps.edn') }}
+          restore-keys: clj-${{ runner.os }}-
+
+      # Java 17 generates class file version 61.0, which is what processing has
+      # been compiled with.
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@11.0
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Install Processing jars
+        run: bb processing-install
+
+      # AOT compile applet-listener and applet
+      - name: AOT Compile
+        run: clojure -T:build aot
+
+      - name: Test
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: clojure -X:test
+
       

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,6 +88,10 @@ jobs:
       - name: Install Processing jars
         run: bb processing-install
 
+      # AOT compile applet-listener and applet so CLJS compile can run
+      - name: AOT Compile
+        run: clojure -Tbuild aot
+
       - name: Test
         uses: coactions/setup-xvfb@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,3 +50,44 @@ jobs:
         uses: coactions/setup-xvfb@v1
         with:
           run: lein test
+
+  test-cljs:
+    name: Test ClojureScript
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cache deps.edn dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: cljs-${{ runner.os }}-${{ hashFiles('**/deps.edn') }}
+          restore-keys: cljs-${{ runner.os }}-
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@11.0
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Test
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: clojure -Mfig:cljs-test
+      
+      

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,11 +73,13 @@ jobs:
           key: cljs-${{ runner.os }}-${{ hashFiles('**/deps.edn') }}
           restore-keys: cljs-${{ runner.os }}-
 
-      - name: Setup Java 11
+      # Java 17 generates class file version 61.0, which is what processing has
+      # been compiled with.
+      - name: Setup Java 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@11.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,7 +90,7 @@ jobs:
 
       # AOT compile applet-listener and applet so CLJS compile can run
       - name: AOT Compile
-        run: clojure -Tbuild aot
+        run: clojure -T:build aot
 
       - name: Test
         uses: coactions/setup-xvfb@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,6 +85,9 @@ jobs:
           cli: latest
           bb: latest
 
+      - name: Install Processing jars
+        run: bb processing-install
+
       - name: Test
         uses: coactions/setup-xvfb@v1
         with:

--- a/build.clj
+++ b/build.clj
@@ -29,7 +29,10 @@
 (def jar-file (format "target/%s-%s.jar" (name lib) version))
 
 (defn clean [_]
-  (b/delete {:path "target"}))
+  ;; release directory
+  (b/delete {:path "target"})
+  ;; aot classes
+  (b/delete {:path "classes"}))
 
 (defn release [_]
   (b/copy-dir {:src-dirs ["src/clj" "src/cljc" "src/cljs" "resources"]
@@ -43,3 +46,11 @@
            :basis basis
            ;; don't bundle clojure into the jar
            :exclude ["^clojure[/].+"]}))
+
+;; clj -T:build aot
+(defn aot [_]
+  (b/compile-clj
+   {:basis basis
+    :src-dirs ["src/clj" "src/cljc" "src/cljs"]
+    :class-dir "classes"
+    :ns-compile ['quil.helpers.applet-listener 'quil.applet]}))

--- a/deps.edn
+++ b/deps.edn
@@ -30,7 +30,15 @@
                    :ns-default build}
            ;; not picking up all test namespaces, probably has to do with :pattern
            :test {:extra-paths ["test/clj" "test/clj/quil"]
-                  :extra-deps {io.github.cognitect-labs/test-runner 
+                  :extra-deps {io.github.cognitect-labs/test-runner
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
                   :main-opts ["-m" "cognitect.test-runner"]
-                  :exec-fn cognitect.test-runner.api/test}}}
+                  :exec-fn cognitect.test-runner.api/test}
+
+           :fig
+           {:extra-deps {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
+                         com.bhauman/figwheel-main {:mvn/version "0.2.18"}}}
+
+           :cljs-test
+           {:main-opts ["-m" "figwheel.main" "-co" "test.cljs.edn" "-m" "quil.test-runner"]
+            :extra-paths ["target" "test"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -28,8 +28,9 @@
         cljsjs/p5 {:mvn/version "1.7.0-0"}}
  :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}}
                    :ns-default build}
+           ;; clj -X:test
            ;; not picking up all test namespaces, probably has to do with :pattern
-           :test {:extra-paths ["test/clj" "test/clj/quil"]
+           :test {:extra-paths ["test/clj" "test/clj/quil" "test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
                   :main-opts ["-m" "cognitect.test-runner"]

--- a/deps.edn
+++ b/deps.edn
@@ -36,9 +36,13 @@
                   :exec-fn cognitect.test-runner.api/test}
 
            :fig
-           {:extra-deps {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
-                         com.bhauman/figwheel-main {:mvn/version "0.2.18"}}}
+           {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.60"}
+                         fipp/fipp {:mvn/version "0.6.26"} ;; better diff output
+                         com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
+                         com.bhauman/figwheel-main {:mvn/version "0.2.18"}}
+            :extra-paths ["resources"]}
 
+           ;; clj -Mfig:cljs-test
            :cljs-test
            {:main-opts ["-m" "figwheel.main" "-co" "test.cljs.edn" "-m" "quil.test-runner"]
             :extra-paths ["target" "test"]}}}

--- a/figwheel-main.edn
+++ b/figwheel-main.edn
@@ -1,0 +1,2 @@
+{:ring-server-options {:port 9500}
+ :open-file-command "emacsclient"}

--- a/resources/public/test.html
+++ b/resources/public/test.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div id="app-tests">
+    <script src="cljs-out/test-main.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/test.cljs.edn
+++ b/test.cljs.edn
@@ -1,5 +1,7 @@
 ^{:ring-server-options {:port 9501}
   :open-url "http://[[server-hostname]]:[[server-port]]/test.html"
+  :log-level :all
+  :client-log-level :finest
   ;; headless is hanging?
   ;; :launch-js ["google-chrome" "--headless" "--repl" "--disable-gpu" :open-url]
   ;; :launch-js ["firefox" :open-url]

--- a/test.cljs.edn
+++ b/test.cljs.edn
@@ -1,0 +1,4 @@
+^{:ring-server-options {:port 9501}
+  :open-url "http://[[server-hostname]]:[[server-port]]/test.html"}
+
+{:main quil.test-runner}

--- a/test.cljs.edn
+++ b/test.cljs.edn
@@ -1,4 +1,8 @@
 ^{:ring-server-options {:port 9501}
-  :open-url "http://[[server-hostname]]:[[server-port]]/test.html"}
+  :open-url "http://[[server-hostname]]:[[server-port]]/test.html"
+  ;; headless is hanging?
+  ;; :launch-js ["google-chrome" "--headless" "--repl" "--disable-gpu" :open-url]
+  ;; :launch-js ["firefox" :open-url]
+  }
 
 {:main quil.test-runner}

--- a/test/quil/calculation_test.cljc
+++ b/test/quil/calculation_test.cljc
@@ -4,6 +4,11 @@
    #_[quil.core :as q :include-macros true]
    ))
 
+(deftest verify-browser
+  (is (empty? (.-userAgent js/navigator)))
+  (is (empty? (.-appName js/navigator)))
+  (is (empty? (.-appVersion js/navigator))))
+
 (deftest absolute-value
   (is (= 1 (abs -1)))
   #_(q/with-sketch (q/sketch :host "abs-test")

--- a/test/quil/calculation_test.cljc
+++ b/test/quil/calculation_test.cljc
@@ -4,11 +4,6 @@
    #_[quil.core :as q :include-macros true]
    ))
 
-(deftest verify-browser
-  (is (empty? (.-userAgent js/navigator)))
-  (is (empty? (.-appName js/navigator)))
-  (is (empty? (.-appVersion js/navigator))))
-
 (deftest absolute-value
   (is (= 1 (abs -1)))
   #_(q/with-sketch (q/sketch :host "abs-test")

--- a/test/quil/calculation_test.cljc
+++ b/test/quil/calculation_test.cljc
@@ -10,10 +10,19 @@
        (.appendChild (.-body js/document) canvas)
        canvas)))
 
+#?(:cljs
+   (defn test-sketch
+     ([] (test-sketch (gensym "quil-sketch")))
+     ([id] (q/sketch :host (make-canvas id))))
+
+   :clj
+   (defn test-sketch []
+     (q/sketch)))
+
 ;; invocation works for cljs with browser, fix for CLJ invocation
 (deftest absolute-value
   (is (= 1 (abs -1)))
-  (q/with-sketch (q/sketch :host (make-canvas "abs-test"))
+  (q/with-sketch (test-sketch)
     (is (= 0 (q/abs 0)))
     (is (= 1 (q/abs -1)))
     (is (= 2 (q/abs 2)))

--- a/test/quil/calculation_test.cljc
+++ b/test/quil/calculation_test.cljc
@@ -1,15 +1,22 @@
 (ns quil.calculation-test
   (:require
    [clojure.test :as t :refer [deftest is] :include-macros true]
-   #_[quil.core :as q :include-macros true]
-   ))
+   [quil.core :as q :include-macros true]))
 
+#?(:cljs
+   (defn make-canvas [id]
+     (let [canvas (.createElement js/document "canvas")]
+       (.setAttribute canvas "id" id)
+       (.appendChild (.-body js/document) canvas)
+       canvas)))
+
+;; invocation works for cljs with browser, fix for CLJ invocation
 (deftest absolute-value
   (is (= 1 (abs -1)))
-  #_(q/with-sketch (q/sketch :host "abs-test")
-      (is (= 0 (q/abs 0)))
-      (is (= 1 (q/abs -1)))
-      (is (= 2 (q/abs 2)))
-      (is (= 0.5 (q/abs -0.5)))
-      (is (= 1.5 (q/abs 1.5)))
-      (q/close)))
+  (q/with-sketch (q/sketch :host (make-canvas "abs-test"))
+    (is (= 0 (q/abs 0)))
+    (is (= 1 (q/abs -1)))
+    (is (= 2 (q/abs 2)))
+    (is (= 0.5 (q/abs -0.5)))
+    (is (= 1.5 (q/abs 1.5)))
+    (q/exit)))

--- a/test/quil/calculation_test.cljc
+++ b/test/quil/calculation_test.cljc
@@ -1,12 +1,12 @@
 (ns quil.calculation-test
   (:require
    [clojure.test :as t :refer [deftest is] :include-macros true]
-   [quil.test-helpers :as qth]
+   [quil.test-helpers :as qth :include-macros true]
    [quil.core :as q :include-macros true]))
 
 (deftest absolute-value
   (is (= 1 (abs -1)))
-  (q/with-sketch (qth/test-sketch)
+  (qth/with-sketch (qth/test-sketch)
     (is (= 0 (q/abs 0)))
     (is (= 1 (q/abs -1)))
     (is (= 2 (q/abs 2)))

--- a/test/quil/calculation_test.cljc
+++ b/test/quil/calculation_test.cljc
@@ -1,0 +1,15 @@
+(ns quil.calculation-test
+  (:require
+   [clojure.test :as t :refer [deftest is] :include-macros true]
+   #_[quil.core :as q :include-macros true]
+   ))
+
+(deftest absolute-value
+  (is (= 1 (abs -1)))
+  #_(q/with-sketch (q/sketch :host "abs-test")
+      (is (= 0 (q/abs 0)))
+      (is (= 1 (q/abs -1)))
+      (is (= 2 (q/abs 2)))
+      (is (= 0.5 (q/abs -0.5)))
+      (is (= 1.5 (q/abs 1.5)))
+      (q/close)))

--- a/test/quil/calculation_test.cljc
+++ b/test/quil/calculation_test.cljc
@@ -1,28 +1,12 @@
 (ns quil.calculation-test
   (:require
    [clojure.test :as t :refer [deftest is] :include-macros true]
+   [quil.test-helpers :as qth]
    [quil.core :as q :include-macros true]))
 
-#?(:cljs
-   (defn make-canvas [id]
-     (let [canvas (.createElement js/document "canvas")]
-       (.setAttribute canvas "id" id)
-       (.appendChild (.-body js/document) canvas)
-       canvas)))
-
-#?(:cljs
-   (defn test-sketch
-     ([] (test-sketch (gensym "quil-sketch")))
-     ([id] (q/sketch :host (make-canvas id))))
-
-   :clj
-   (defn test-sketch []
-     (q/sketch)))
-
-;; invocation works for cljs with browser, fix for CLJ invocation
 (deftest absolute-value
   (is (= 1 (abs -1)))
-  (q/with-sketch (test-sketch)
+  (q/with-sketch (qth/test-sketch)
     (is (= 0 (q/abs 0)))
     (is (= 1 (q/abs -1)))
     (is (= 2 (q/abs 2)))

--- a/test/quil/test_helpers.cljc
+++ b/test/quil/test_helpers.cljc
@@ -1,5 +1,12 @@
 (ns quil.test-helpers
-  (:require [quil.core :as q :include-macros true]))
+  #?(:clj
+     (:require
+      [quil.core :as q]
+      [quil.applet])
+     :cljs
+     (:require
+      [quil.core :as q :include-macros true]
+      [quil.sketch])))
 
 #?(:cljs
    (defn make-canvas [id]
@@ -16,3 +23,15 @@
    :clj
    (defn test-sketch []
      (q/sketch)))
+
+;; FIXME possibly unify this with quil.core/with-sketch
+;; and possibly deprecate quil.applet/with-applet?
+(defmacro with-sketch [applet & body]
+  ;; BEWARE DRAGONS!
+  ;; https://groups.google.com/g/clojurescript/c/iBY5HaQda4A/m/w1lAQi9_AwsJ
+  ;; if &env has a ns, evaluate macros in cljs context
+  (if (boolean (:ns &env))
+    `(binding [quil.sketch/*applet* ~applet]
+       ~@body)
+    `(binding [quil.applet/*applet* ~applet]
+       ~@body)))

--- a/test/quil/test_helpers.cljc
+++ b/test/quil/test_helpers.cljc
@@ -1,0 +1,18 @@
+(ns quil.test-helpers
+  (:require [quil.core :as q :include-macros true]))
+
+#?(:cljs
+   (defn make-canvas [id]
+     (let [canvas (.createElement js/document "canvas")]
+       (.setAttribute canvas "id" id)
+       (.appendChild (.-body js/document) canvas)
+       canvas)))
+
+#?(:cljs
+   (defn test-sketch
+     ([] (test-sketch (gensym "quil-sketch")))
+     ([id] (q/sketch :host (make-canvas id))))
+
+   :clj
+   (defn test-sketch []
+     (q/sketch)))

--- a/test/quil/test_runner.cljs
+++ b/test/quil/test_runner.cljs
@@ -1,44 +1,11 @@
-(ns ^:figwheel-hooks quil.test-runner
+(ns quil.test-runner
   (:require
-   [cljs-test-display.core :as td]
-   [figwheel.main.testing :refer [run-tests-async run-tests]]
-   [fipp.edn :as fedn]
-   [goog.dom :as gdom]
+   [cljs.test]
+   [figwheel.main.testing :refer-macros [run-tests-async]]
 
    ;; require namespaces to tests
    quil.calculation-test
    ))
-
-(enable-console-print!)
-
-(defn prettier [content]
-  (td/n :pre {}
-        (td/n :code {} (with-out-str (fedn/pprint content {:width 100})))))
-
-;; modified from https://github.com/bhauman/cljs-test-display/issues/5#issuecomment-619090019
-;; pretty print expected vs actual with fedn/pprint
-(set! td/comparison
-      (fn comparison [{:keys [expected actual]}]
-        (td/div
-         (prettier expected)
-         (td/div :actual-x (prettier actual)))))
-
-(def style-overrides
-  "pre {overflow-x: auto;}
-.actual-x {border-top: 1.5px dashed rgb(236 196 196);}
-")
-
-;; to view, visit http://localhost:9600/figwheel-extra-main/tests
-(defn ^:after-load test-run []
-  (run-tests (cljs-test-display.core/init! "app-tests"))
-  (when-not (gdom/getElement "style-override")
-    (let [head (aget (gdom/getElementsByTagName "head") 0)]
-      (gdom/appendChild head
-                        (td/n :style {:id "style-override"}
-                              style-overrides)))))
-
-(defonce initialize-page
-  (test-run))
 
 (defn -main [& _args]
   (run-tests-async 5000))

--- a/test/quil/test_runner.cljs
+++ b/test/quil/test_runner.cljs
@@ -1,11 +1,17 @@
 (ns quil.test-runner
   (:require
-   [cljs.test]
+   #_[clojure.test :as t :refer [deftest is] :include-macros true]
    [figwheel.main.testing :refer-macros [run-tests-async]]
 
    ;; require namespaces to tests
    quil.calculation-test
    ))
+
+;; uncomment to verify browser version
+#_(deftest verify-browser
+    (is (empty? (.-userAgent js/navigator)))
+    (is (empty? (.-appName js/navigator)))
+    (is (empty? (.-appVersion js/navigator))))
 
 (defn -main [& _args]
   (run-tests-async 5000))

--- a/test/quil/test_runner.cljs
+++ b/test/quil/test_runner.cljs
@@ -1,0 +1,44 @@
+(ns ^:figwheel-hooks quil.test-runner
+  (:require
+   [cljs-test-display.core :as td]
+   [figwheel.main.testing :refer [run-tests-async run-tests]]
+   [fipp.edn :as fedn]
+   [goog.dom :as gdom]
+
+   ;; require namespaces to tests
+   quil.calculation-test
+   ))
+
+(enable-console-print!)
+
+(defn prettier [content]
+  (td/n :pre {}
+        (td/n :code {} (with-out-str (fedn/pprint content {:width 100})))))
+
+;; modified from https://github.com/bhauman/cljs-test-display/issues/5#issuecomment-619090019
+;; pretty print expected vs actual with fedn/pprint
+(set! td/comparison
+      (fn comparison [{:keys [expected actual]}]
+        (td/div
+         (prettier expected)
+         (td/div :actual-x (prettier actual)))))
+
+(def style-overrides
+  "pre {overflow-x: auto;}
+.actual-x {border-top: 1.5px dashed rgb(236 196 196);}
+")
+
+;; to view, visit http://localhost:9600/figwheel-extra-main/tests
+(defn ^:after-load test-run []
+  (run-tests (cljs-test-display.core/init! "app-tests"))
+  (when-not (gdom/getElement "style-override")
+    (let [head (aget (gdom/getElementsByTagName "head") 0)]
+      (gdom/appendChild head
+                        (td/n :style {:id "style-override"}
+                              style-overrides)))))
+
+(defonce initialize-page
+  (test-run))
+
+(defn -main [& _args]
+  (run-tests-async 5000))


### PR DESCRIPTION
New test automation harness for running tests against both Processing and p5js derived sketches.

For ClojureScript p5js sketches, it makes assertions against a canvas in a browser with an attached p5js applet. For Clojure based Processing sketches, it instantiates a Processing applet and makes assertions in that context. The test harness uses standard clojure.test assertions in a CLJC file and the suite is run on every branch/pull request submitted using Github Actions.