### PR TITLE
Separate aot and release jar steps

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -34,23 +34,19 @@
   ;; aot classes
   (b/delete {:path "classes"}))
 
-(defn release [_]
+;; clj -T:build aot
+(defn aot [_]
   (b/copy-dir {:src-dirs ["src/clj" "src/cljc" "src/cljs" "resources"]
                :target-dir class-dir})
   (b/compile-clj {:basis basis
                   :src-dirs ["src/clj" "src/cljc" "src/cljs"]
                   :class-dir class-dir
-                  :ns-compile ['quil.helpers.applet-listener 'quil.applet 'quil.sketch]})
+                  :ns-compile ['quil.helpers.applet-listener 'quil.applet 'quil.sketch]}))
+
+(defn release [_]
+  (aot _)
   (b/uber {:class-dir class-dir
            :uber-file jar-file
            :basis basis
            ;; don't bundle clojure into the jar
            :exclude ["^clojure[/].+"]}))
-
-;; clj -T:build aot
-(defn aot [_]
-  (b/compile-clj
-   {:basis basis
-    :src-dirs ["src/clj" "src/cljc" "src/cljs"]
-    :class-dir "classes"
-    :ns-compile ['quil.helpers.applet-listener 'quil.applet]}))

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,8 @@
 {:description "(mix Processing Clojure)"
  :url "http://github.com/quil/quil"
- :paths ["src/clj" "src/cljc" "src/cljs" "classes"]
+ :paths ["src/clj" "src/cljc" "src/cljs"
+         ;; generated with clojure -T:build aot
+         "target/classes"]
  :resource-paths ["resources"]
  :mvn/repos {"jogl" {:url "https://jogamp.org/deployment/maven/"}}
  :deps {quil/processing-core {:local/root "libraries/core.jar"}


### PR DESCRIPTION
Instead of creating target/classes and classes depending on if we are releasing or just doing a simple AOT compilation step, change the default classpath to reference target/classes, and split the aot and release steps such that aot always populates target/classes and release does that + building a jar file.