### PR TITLE
Run CLJ tests on macOSX

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,7 +111,7 @@ jobs:
           # failing on invalid path in git checkout:
           # 'dev-resources/snippet-snapshots/clj/normal/font-available?-s-expected.png'
           # - windows-latest
-        java-version: [17,20]
+        java-version: [17] # ,20 to test jdk20
 
     runs-on: ${{ matrix.os }}
 
@@ -123,12 +123,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: clj-${{ runner.os }}-${{ matrix.java-version }}-${{ hashFiles('**/deps.edn') }}
-          restore-keys: clj-${{ runner.os }}-${{ matrix.java-version }}-
+          key: clj-${{ runner.os }}-jdk${{ matrix.java-version }}-${{ hashFiles('**/deps.edn') }}
+          restore-keys: clj-${{ runner.os }}-jdk${{ matrix.java-version }}-
 
       # Java 17 generates class file version 61.0, which is what processing has
       # been compiled with.
-      - name: Setup Java 17
+      - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -108,7 +108,9 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
+          # failing on invalid path in git checkout:
+          # 'dev-resources/snippet-snapshots/clj/normal/font-available?-s-expected.png'
+          # - windows-latest
         java-version: [17,20]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -109,6 +109,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        java-version: [17,20]
 
     runs-on: ${{ matrix.os }}
 
@@ -129,7 +130,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: ${{matrix.java-version}}
 
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@11.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,8 +121,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: clj-${{ runner.os }}-${{ hashFiles('**/deps.edn') }}
-          restore-keys: clj-${{ runner.os }}-
+          key: clj-${{ runner.os }}-${{ matrix.java-version }}-${{ hashFiles('**/deps.edn') }}
+          restore-keys: clj-${{ runner.os }}-${{ matrix.java-version }}-
 
       # Java 17 generates class file version 61.0, which is what processing has
       # been compiled with.
@@ -130,7 +130,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: ${{matrix.java-version}}
+          java-version: ${{ matrix.java-version }}
 
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@11.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -107,6 +107,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macOS-latest
+          - windows-latest
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Enables testing on macOSX-latest. Windows is broken from path problems during checkout, will have to address that later. 

Matrix builds can support multiple JDK versions if we need it, but keeping it at the minimum required seems good enough for now.