### PR TITLE
Fix resize/fullscreen for p5js based sketches

### DIFF
--- a/src/cljs/quil/sketch.cljs
+++ b/src/cljs/quil/sketch.cljs
@@ -22,19 +22,7 @@
     (u/resolve-constant-key mode rendering-modes)))
 
 (defn set-size [applet width height]
-  (when-let [el (.-quil-canvas applet)]
-    ; p5js creates a <canvas> element inside provided <div> element
-    ; we need to resize only the canvas as outer div will adapt automatically
-    (let [inner-canvas (.querySelector el "canvas")]
-      (.resizeCanvas applet width height)
-      (.setAttribute inner-canvas "width" width)
-      (.setAttribute inner-canvas "height" height)
-      (aset (.-style inner-canvas) "width" (str width "px"))
-      (aset (.-style inner-canvas) "height" (str height "px"))
-      (set! (.-width applet)
-            (.parseInt js/window (style/getComputedStyle inner-canvas "width")))
-      (set! (.-height applet)
-            (.parseInt js/window (style/getComputedStyle inner-canvas "height"))))))
+  (.resizeCanvas applet width height))
 
 (defn size
   ([width height]

--- a/test/cljs/quil/examples.cljs
+++ b/test/cljs/quil/examples.cljs
@@ -1,0 +1,27 @@
+(ns quil.examples
+  (:require [quil.core :as q :include-macros true]))
+
+;; used for both manual resize and fullscreen tests
+(defn resize [host]
+  (q/sketch
+   :host host
+   :size [500 500]
+   :draw (fn []
+           (q/background 240)
+           (q/text-size 20)
+           (q/fill 0)
+           (q/text-align :left :top)
+           (q/text (str "width: " (q/width)
+                        "\nheight: " (q/height)
+                        "\ndensity: " (q/display-density))
+                   10 10)
+
+           ;; FIXME: after resize cross hairs are on lower, right edges because
+           ;; width/height of canvas element changes from style width/height.
+           ;; initial canvas has width/height 1000x1000, but after resize it is
+           ;; 700x700 and 500x500 but only showing the upper left quadrant of
+           ;; the canvas.
+           (q/ellipse (/ (q/width) 4) (/ (q/height) 4) 10 10)
+           (q/line 0 (/ (q/height) 2) (q/width) (/ (q/height) 2))
+           (q/line (/ (q/width) 2) 0 (/ (q/width) 2) (q/height)))))
+

--- a/test/cljs/quil/examples.cljs
+++ b/test/cljs/quil/examples.cljs
@@ -16,11 +16,6 @@
                         "\ndensity: " (q/display-density))
                    10 10)
 
-           ;; FIXME: after resize cross hairs are on lower, right edges because
-           ;; width/height of canvas element changes from style width/height.
-           ;; initial canvas has width/height 1000x1000, but after resize it is
-           ;; 700x700 and 500x500 but only showing the upper left quadrant of
-           ;; the canvas.
            (q/ellipse (/ (q/width) 4) (/ (q/height) 4) 10 10)
            (q/line 0 (/ (q/height) 2) (q/width) (/ (q/height) 2))
            (q/line (/ (q/width) 2) 0 (/ (q/width) 2) (q/height)))))

--- a/test/cljs/quil/fullscreen.cljs
+++ b/test/cljs/quil/fullscreen.cljs
@@ -1,22 +1,10 @@
 (ns quil.fullscreen
-  (:require [quil.core :as q :include-macros true]
-            [quil.middlewares.fun-mode :as fm]
+  (:require [quil.examples :as qe]
             [goog.events :as events]
             [goog.events.EventType :as EventType]))
 
 (defn start-sketch []
-  (q/sketch
-   :host "fullscreen"
-   :size [500 500]
-   :draw (fn []
-           (q/background 240)
-           (q/text-size 30)
-           (q/fill 0)
-           (q/text-align :center :center)
-           (q/text (str "width: " (q/width)
-                        "\nheight: " (q/height))
-                   (/ (q/width) 2)
-                   (/ (q/height) 2)))))
+  (qe/resize "fullscreen"))
 
 (events/listenOnce js/window EventType/LOAD
                    #(when (= (-> js/document

--- a/test/cljs/quil/manual.cljs
+++ b/test/cljs/quil/manual.cljs
@@ -1,5 +1,6 @@
 (ns quil.manual
   (:require [quil.core :as q :include-macros true]
+            [quil.examples :as qe]
             [quil.middlewares.fun-mode :as fm]
             [goog.events :as events]
             [goog.events.EventType :as EventType]))
@@ -184,27 +185,8 @@
            (q/fill 0 0 0)
            (q/text (str "mouse pressed: "  (q/mouse-pressed?)) 0 20)
            (q/text (str "key pressed: " (q/key-pressed?)) 0 40)))
-  (q/sketch
-   :host "resizing"
-   :size [500 500]
-   :draw (fn []
-           (q/background 240)
-           (q/text-size 20)
-           (q/fill 0)
-           (q/text-align :left :top)
-           (q/text (str "width: " (q/width)
-                        "\nheight: " (q/height)
-                        "\ndensity: " (q/display-density))
-                   10 10)
 
-           ;; FIXME: after resize cross hairs are on lower, right edges because
-           ;; width/height of canvas element changes from style width/height.
-           ;; initial canvas has width/height 1000x1000, but after resize it is
-           ;; 700x700 and 500x500 but only showing the upper left quadrant of
-           ;; the canvas.
-           (q/ellipse (/ (q/width) 4) (/ (q/height) 4) 10 10)
-           (q/line 0 (/ (q/height) 2) (q/width) (/ (q/height) 2))
-           (q/line (/ (q/width) 2) 0 (/ (q/width) 2) (q/height)))))
+  (qe/resize "resizing"))
 
 (defn resize-sketch []
   (.setTimeout js/window

--- a/test/cljs/quil/manual.cljs
+++ b/test/cljs/quil/manual.cljs
@@ -50,7 +50,7 @@
 (defn start-all-sketches []
   (q/sketch :host "redraw-on-key"
             :size [500 200]
-            ; Just to try :settings instead of usual :setup
+            ;; Just to try :settings instead of usual :setup
             :settings q/no-loop
             :draw (fn []
                     (q/fill 0)
@@ -103,28 +103,28 @@
            (q/background 255)
            (let [gr (q/create-graphics 100 100)]
 
-             ; draw ellipse in gr object
+             ;; draw ellipse in gr object
              (q/with-graphics gr
                (q/background 255)
                (q/fill 127 255 180)
                (q/ellipse 50 50 70 70))
 
-             ; draw gr object on screen
+             ;; draw gr object on screen
              (q/image gr 0 0)
 
-             ; draw gr object on screen using get-pixel
+             ;; draw gr object on screen using get-pixel
              (q/image (q/get-pixel gr) 0 120)
 
-             ; set fill color to the same as ellipse and
-             ; draw rectangle
+             ;; set fill color to the same as ellipse and
+             ;; draw rectangle
              (q/fill (q/get-pixel gr 50 50))
              (q/rect 120 0 100 100)
 
-             ; draw up left quarter of ellipse on screen
+             ;; draw up left quarter of ellipse on screen
              (q/image (q/get-pixel gr 0 0 50 50) 120 120)
 
-             ; set fill to white using get-pixel of [0, 0]
-             ; point of the screen and draw white rectangle
+             ;; set fill to white using get-pixel of [0, 0]
+             ;; point of the screen and draw white rectangle
              (q/fill (q/get-pixel 0 0))
              (q/rect 240 0 100 100))
            (q/no-loop)))

--- a/test/cljs/quil/manual.cljs
+++ b/test/cljs/quil/manual.cljs
@@ -189,13 +189,22 @@
    :size [500 500]
    :draw (fn []
            (q/background 240)
-           (q/text-size 30)
+           (q/text-size 20)
            (q/fill 0)
-           (q/text-align :center :center)
+           (q/text-align :left :top)
            (q/text (str "width: " (q/width)
-                        "\nheight: " (q/height))
-                   (/ (q/width) 2)
-                   (/ (q/height) 2)))))
+                        "\nheight: " (q/height)
+                        "\ndensity: " (q/display-density))
+                   10 10)
+
+           ;; FIXME: after resize cross hairs are on lower, right edges because
+           ;; width/height of canvas element changes from style width/height.
+           ;; initial canvas has width/height 1000x1000, but after resize it is
+           ;; 700x700 and 500x500 but only showing the upper left quadrant of
+           ;; the canvas.
+           (q/ellipse (/ (q/width) 4) (/ (q/height) 4) 10 10)
+           (q/line 0 (/ (q/height) 2) (q/width) (/ (q/height) 2))
+           (q/line (/ (q/width) 2) 0 (/ (q/width) 2) (q/height)))))
 
 (defn resize-sketch []
   (.setTimeout js/window


### PR DESCRIPTION
p5js [resizeCanvas](
https://p5js.org/reference/#/p5/resizeCanvas) appears to correctly handle updating the canvas width and height, both for the element and style. Previously, resizing a canvas would adjust the screen coordinate system for the canvas, such that it was just showing the upper left quadrant, but if resizeCanvas is used directly it appears to rescale correctly. The behavior without this fix effectively quarters the visible canvas size after a resize event.

However, this behavior may be somewhat related to screen density and zoom. Testing with the responsive view on Chrome  left a few places where the vertical bar was missing even though text and the horizontal bar was centered at 100% zoom on devices with different display density. Tested in firefox as well, but wasn't able to find the responsive controls, but the defaults were working. In the case of fullscreen, the `add-fullscreen-support` method calculates window screen width/height as arguments to `set-size`, so we should not need to calculate the size of the element in resize.

By default p5js appears to create a canvas that *thinks* it's width/height 1000x1000 and then styles it like it's a smaller area which I think is where the "quartering" effect occurs. Digging deeper into the p5js renderer it does appear to be rescaling the screen size proportional to screen density in [Renderer.resize()](https://github.com/processing/p5.js/blob/v1.8.0/src/core/p5.Renderer.js#L123) and [Renderer2d.resize()](https://github.com/processing/p5.js/blob/v1.8.0/src/core/p5.Renderer2D.js#L30). That matches what [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas#scaling_for_high_resolution_displays) recommends for high density screens.

Overall, I suspect there are still edge cases with this new behavior, but it seems far more reliable than the current behavior.