### PR TITLE
Release tooling

### DIFF
--- a/.github/workflows/clojars_release.yaml
+++ b/.github/workflows/clojars_release.yaml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  clojars-snapshot-release:
+    name: Clojars Snapshot Release
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Java 17 generates class file version 61.0, which is what processing has
+      # been compiled with.
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@11.0
+        with:
+          cli: latest
+          bb: latest
+
+      - name: System Info
+        run: bb system-info
+
+      - name: Install Processing jars
+        run: bb processing-install
+
+      - name: Build release jar
+        run: clojure -T:build release :snapshot true
+
+      - name: Deploy JAR
+        run: clojure -T:build deploy :snapshot true
+        env:
+          CLOJARS_USERNAME: ${{secrets.CLOJARS_USERNAME}}
+          CLOJARS_PASSWORD: ${{secrets.CLOJARS_DEPLOY_TOKEN}}

--- a/.github/workflows/clojars_snapshot_release.yaml
+++ b/.github/workflows/clojars_snapshot_release.yaml
@@ -1,13 +1,11 @@
-name: Clojars Release
+name: Snapshot Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
 
 jobs:
   clojars-snapshot-release:
-    name: Clojars Release
+    name: Clojars Snapshot Release
 
     runs-on: ubuntu-latest
 
@@ -36,10 +34,10 @@ jobs:
         run: bb processing-install
 
       - name: Build release jar
-        run: clojure -T:build release
+        run: clojure -T:build release :snapshot true
 
       - name: Deploy JAR
-        run: clojure -T:build deploy :clojars true
+        run: clojure -T:build deploy :snapshot true
         env:
           CLOJARS_USERNAME: ${{secrets.CLOJARS_USERNAME}}
           CLOJARS_PASSWORD: ${{secrets.CLOJARS_DEPLOY_TOKEN}}

--- a/build.clj
+++ b/build.clj
@@ -114,6 +114,6 @@
              (format "(%.1f kb)" (/ (.length (jio/file jar-file)) 1024.0)))))
 
 (defn deploy [opts]
-  (dd/deploy {:installer :local
+  (dd/deploy {:installer (if (:clojars opts) :remote :local)
               :artifact (b/resolve-path (jar-file opts))
               :pom-file "pom.xml"}))

--- a/build.clj
+++ b/build.clj
@@ -28,7 +28,6 @@
 (def version (format "4.3.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
-(def jar-file (format "target/%s-%s.jar" (name lib) version))
 
 (defn clean [_]
   ;; release directory
@@ -82,13 +81,17 @@
        pom-template
        xml/sexp-as-element
        xml/indent-str
-       (spit (jio/file "." "pom.xml"))))
+       (spit (jio/file "." "pom.xml")))
+  (println "Generated pom.xml for version:" version))
 
 (defn release [_]
   (aot _)
   (pom _)
-  (b/uber {:class-dir class-dir
-           :uber-file jar-file
-           :basis basis
-           ;; don't bundle clojure into the jar
-           :exclude ["^clojure[/].+"]}))
+  (let [jar-file (format "target/%s-%s.jar" (name lib) version)]
+    (b/uber {:class-dir class-dir
+             :uber-file jar-file
+             :basis basis
+             ;; don't bundle clojure into the jar
+             :exclude ["^clojure[/].+"]})
+    (println "release:" jar-file
+             (format "(%.1f kb)" (/ (.length (jio/file jar-file)) 1024.0)))))

--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,8 @@
 
         ;; clojurescript p5js
         cljsjs/p5 {:mvn/version "1.7.0-0"}}
- :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}}
+ :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}
+                          slipset/deps-deploy {:mvn/version "RELEASE"}}
                    :ns-default build}
 
            :dev

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
   <version>4.3-SNAPSHOT</version>
   <name>quil</name>
   <licenses>
-	<license>
-	  <name>Eclipse Public License 2.0</name>
-	  <url>https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt</url>
+    <license>
+      <name>Eclipse Public License 2.0</name>
+      <url>https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt</url>
     </license>
   </licenses>
   <dependencies>


### PR DESCRIPTION
Creates a Github Action for creating jar releases to Clojars, both for snapshot releases on current HEAD, and for actual releases.

Snapshot releases are in the form of `VERSION.$rev-count.$git-sha-SNAPSHOT`, and final Clojar releases are in the form of `VERSION.$build-revision`.

For now SNAPSHOT releases are deployed to local .m2 repo to verify behavior. Once that is confirmed, will set :clojars true to allow manual generation of a snapshot release by triggering an action. Versioned releases are triggered on pushing a tag like: `v$VERSION.$rev-count`.