### PR TITLE
Upload processing jars to Clojars

### DIFF
--- a/.github/workflows/publish_processing.yaml
+++ b/.github/workflows/publish_processing.yaml
@@ -1,0 +1,37 @@
+name: Publish Processing to Clojars
+
+run-name: ${{ github.actor }} published Processing to Clojars
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-processing:
+    name: Publish Processing
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@12.1
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Deploy Processing to Clojars
+        run: clojure -T:build processing-clojars :deploy :remote
+        env:
+          CLOJARS_USERNAME: ${{secrets.CLOJARS_USERNAME}}
+          CLOJARS_PASSWORD: ${{secrets.CLOJARS_DEPLOY_TOKEN}}
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -103,8 +103,8 @@ jobs:
       - name: System Info
         run: bb system-info
 
-      - name: Install Processing jars
-        run: bb processing-install
+      - name: Install Processing jars to local m2
+        run: clojure -T:build processing-clojars
 
       # AOT compile applet-listener and applet so CLJS compile can run
       - name: AOT Compile
@@ -158,8 +158,8 @@ jobs:
       - name: System Info
         run: bb system-info
 
-      - name: Install Processing jars
-        run: bb processing-install
+      - name: Install Processing jars to local m2
+        run: clojure -T:build processing-clojars
 
       # AOT compile applet-listener and applet
       - name: AOT Compile

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   push:
-  pull_request:
 
 jobs:
   test-leiningen:

--- a/build.clj
+++ b/build.clj
@@ -29,7 +29,9 @@
 
 (def lib 'quil/quil)
 (def class-dir "target/classes")
-(def basis (b/create-basis {:project "deps.edn"}))
+;; create-basis will side-effect and verify the deps, which we may not want if
+;; uploading new versions of said dependencies
+(def basis (delay (b/create-basis {:project "deps.edn"})))
 
 (defn release-version
   "Create a version id for release
@@ -56,7 +58,7 @@
 (defn aot [_]
   (b/copy-dir {:src-dirs ["src/clj" "src/cljc" "src/cljs" "resources"]
                :target-dir class-dir})
-  (b/compile-clj {:basis basis
+  (b/compile-clj {:basis @basis
                   :src-dirs ["src/clj" "src/cljc" "src/cljs"]
                   :class-dir class-dir
                   :ns-compile ['quil.helpers.applet-listener 'quil.applet 'quil.sketch]}))
@@ -114,7 +116,7 @@
   (let [jar-file (jar-file opts)]
     (b/uber {:class-dir class-dir
              :uber-file jar-file
-             :basis basis
+             :basis @basis
              ;; don't bundle clojure into the jar
              :exclude ["^clojure[/].+"]})
     (println "release:" jar-file

--- a/build.clj
+++ b/build.clj
@@ -125,5 +125,5 @@
               :artifact (b/resolve-path (jar-file opts))
               :pom-file "pom.xml"}))
 
-(defn processing [_]
-  (processing/download _))
+(defn processing-clojars [_]
+  (processing/clojars-release _))

--- a/build.clj
+++ b/build.clj
@@ -1,5 +1,6 @@
 (ns build
   (:require
+   [build.processing :as processing]
    [clojure.data.xml :as xml]
    [clojure.java.io :as jio]
    [clojure.tools.build.api :as b]
@@ -123,3 +124,6 @@
   (dd/deploy {:installer (if (:clojars opts) :remote :local)
               :artifact (b/resolve-path (jar-file opts))
               :pom-file "pom.xml"}))
+
+(defn processing [_]
+  (processing/download _))

--- a/build/processing.clj
+++ b/build/processing.clj
@@ -1,12 +1,14 @@
 (ns build.processing
+  "Publishes copies of the Processing jars to Clojars.
+
+  Processing jars are not published to maven, so publishes copies as
+  quil/processing-{core,pdf,dxf,svg} jars on Clojars so that Quil can depend on
+  them as mvn coordinates instead of locals."
   (:require
    [clojure.data.xml :as xml]
-   [clojure.tools.build.api :as b]
    [clojure.java.io :as io]
+   [clojure.tools.build.api :as b]
    [deps-deploy.deps-deploy :as dd]))
-
-(defn version []
-  "4.2.3")
 
 (xml/alias-uri 'pom "http://maven.apache.org/POM/4.0.0")
 
@@ -43,17 +45,23 @@
               :pom-file pom-file})
   opts)
 
+;; Specify processing version to release both here and in the
+;; bb.processing/install URL
+(def processing-version "4.2.3")
+
 (defn clojars-release [_]
+  ;; TODO: inline processing-install here
   (b/process {:command-args ["bb" "processing-install"]})
 
-  (let [artifacts ["core" "pdf" "dxf" "svg"]]
+  (let [version processing-version
+        artifacts ["core" "pdf" "dxf" "svg"]]
     (doseq [artifact artifacts
             :let [artifact-id (str "processing-" artifact)
-                  jar-file (str artifact-id "-" (version) ".jar")]]
+                  jar-file (str artifact-id "-" version ".jar")]]
       (b/copy-file {:src (str "libraries/" artifact ".jar")
                     :target jar-file})
       (let [pom-file (processing-pom {:artifact-id artifact-id
-                                      :version (version)})]
+                                      :version version})]
         (deploy {:jar-file jar-file
                  :pom-file pom-file
                  :clojars false})

--- a/build/processing.clj
+++ b/build/processing.clj
@@ -39,17 +39,11 @@
     (println "Generated " filename)
     filename))
 
-(defn deploy [{:keys [jar-file pom-file clojars] :as opts}]
-  (dd/deploy {:installer (if clojars :remote :local)
-              :artifact jar-file
-              :pom-file pom-file})
-  opts)
-
 ;; Specify processing version to release both here and in the
 ;; bb.processing/install URL
 (def processing-version "4.2.3")
 
-(defn clojars-release [_]
+(defn clojars-release [opts]
   ;; TODO: inline processing-install here
   (b/process {:command-args ["bb" "processing-install"]})
 
@@ -62,9 +56,9 @@
                     :target jar-file})
       (let [pom-file (processing-pom {:artifact-id artifact-id
                                       :version version})]
-        (deploy {:jar-file jar-file
-                 :pom-file pom-file
-                 :clojars false})
+        (dd/deploy {:installer (get opts :deploy :local)
+                    :artifact jar-file
+                    :pom-file pom-file})
         (b/delete {:path pom-file})
         (b/delete {:path jar-file}))))
-  _)
+  opts)

--- a/build/processing.clj
+++ b/build/processing.clj
@@ -1,10 +1,50 @@
 (ns build.processing
   (:require
-   [clojure.tools.build.api :as b]))
+   [clojure.data.xml :as xml]
+   [clojure.tools.build.api :as b]
+   [clojure.java.io :as io]))
+
+(defn version []
+  "4.2.3")
+
+(xml/alias-uri 'pom "http://maven.apache.org/POM/4.0.0")
+
+(defn- processing-template [{:keys [artifact-id version]}]
+  [::pom/project
+   {:xmlns "http://maven.apache.org/POM/4.0.0"
+    (keyword "xmlns:xsi") "http://www.w3.org/2001/XMLSchema-instance"
+    (keyword "xsi:schemaLocation")
+    "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"}
+   [::pom/modelVersion "4.0.0"]
+   [::pom/packaging "jar"]
+   [::pom/groupId "quil"]
+   [::pom/artifactId artifact-id]
+   [::pom/version version]
+   [::pom/licenses
+    [::pom/license
+     [::pom/name "GNU Lesser General Public License"]
+     [::pom/url "https://www.gnu.org/licenses/lgpl.html"]]]])
+
+(defn processing-pom
+  [{:keys [version artifact-id] :as params}]
+  (let [filename (str artifact-id "-" version "-pom.xml")]
+    (->> params
+         processing-template
+         xml/sexp-as-element
+         xml/indent-str
+         (spit (io/file "." filename)))
+    (println "Generated " filename)
+    filename))
 
 (defn download [_]
   (b/process {:command-args ["bb" "processing-install"]})
+
+  (let [artifacts ["core" "pdf" "dxf" "svg"]]
+    (doseq [artifact artifacts
+            :let [artifact-id (str "processing-" artifact)
+                  jar-file (str artifact-id "-" (version) ".jar")]]
+      (b/copy-file {:src (str "libraries/" artifact ".jar")
+                    :target jar-file})
+      (processing-pom {:artifact-id artifact-id
+                       :version (version)})))
   _)
-
-
-

--- a/build/processing.clj
+++ b/build/processing.clj
@@ -1,0 +1,10 @@
+(ns build.processing
+  (:require
+   [clojure.tools.build.api :as b]))
+
+(defn download [_]
+  (b/process {:command-args ["bb" "processing-install"]})
+  _)
+
+
+

--- a/deps.edn
+++ b/deps.edn
@@ -27,8 +27,10 @@
         com.lowagie/itext {:local/root "libraries/itext.jar"}
 
         ;; svg export
-        org.apache.xmlgraphics/batik-svggen {:local/root "libraries/batik.jar"}
-        org.apache.xmlgraphics/batik-dom {:local/root "libraries/batik.jar"}
+        ;; versions from https://github.com/benfry/processing4/blob/main/java/libraries/svg/build.xml#L6
+        ;; FIXME: push this dependency to processing-svg?
+        org.apache.xmlgraphics/batik-svggen {:mvn/version "1.14"}
+        org.apache.xmlgraphics/batik-dom {:mvn/version "1.14"}
 
         ;; clojurescript p5js
         cljsjs/p5 {:mvn/version "1.7.0-0"}}

--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,11 @@
         org.jogamp.jogl/jogl-all$natives-windows-amd64 {:mvn/version "2.4.0-rc-20230201"}
 
         ;; part of PDF support
-        com.lowagie/itext {:local/root "libraries/itext.jar"}
+        ;; version defined by processing in https://github.com/benfry/processing4/tree/main/java/libraries/pdf
+        ;; see also https://github.com/quil/quil/issues/247
+        com.lowagie/itext {:mvn/version "2.1.7"
+                           :exclusions [bouncycastle/bctsp-jdk14]}
+        org.bouncycastle/bctsp-jdk14 {:mvn/version "1.38"}
 
         ;; svg export
         ;; versions from https://github.com/benfry/processing4/blob/main/java/libraries/svg/build.xml#L6


### PR DESCRIPTION
Automation for publishing copies of processing jars on Clojars to act as mvn/version coordinates for Quil.

For various reasons, Processing does not publish to maven central or other repositories. So this task downloads and unpacks processing and then publishes copies of the core, svg,dxf, and pdf jars to Clojars. This should only be run when Processing publishes a new release and will need to update the URL and processing-version to match.

In addition, this changes quil so the other local/root coordinates reference the corresponding maven coordinates.