### PR TITLE
Use Clojars Processing coordinates

### DIFF
--- a/.github/workflows/clojars_release.yaml
+++ b/.github/workflows/clojars_release.yaml
@@ -34,9 +34,6 @@ jobs:
       - name: System Info
         run: bb system-info
 
-      - name: Install Processing jars
-        run: bb processing-install
-
       - name: Build release jar
         run: clojure -T:build release
 

--- a/.github/workflows/clojars_snapshot_release.yaml
+++ b/.github/workflows/clojars_snapshot_release.yaml
@@ -32,9 +32,6 @@ jobs:
       - name: System Info
         run: bb system-info
 
-      - name: Install Processing jars
-        run: bb processing-install
-
       - name: Build release jar
         run: clojure -T:build release :snapshot true
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,9 +102,6 @@ jobs:
       - name: System Info
         run: bb system-info
 
-      - name: Install Processing jars to local m2
-        run: clojure -T:build processing-clojars
-
       # AOT compile applet-listener and applet so CLJS compile can run
       - name: AOT Compile
         run: clojure -T:build aot
@@ -156,9 +153,6 @@ jobs:
 
       - name: System Info
         run: bb system-info
-
-      - name: Install Processing jars to local m2
-        run: clojure -T:build processing-clojars
 
       # AOT compile applet-listener and applet
       - name: AOT Compile

--- a/deps.edn
+++ b/deps.edn
@@ -71,12 +71,4 @@
            ;; clj -Mfig:cljs-test
            :cljs-test
            {:main-opts ["-m" "figwheel.main" "-co" "test.cljs.edn" "-m" "quil.test-runner"]
-            :extra-paths ["target" "test"]}
-
-           ;; (N.B. update pom.xml before you do this!)
-           ;; env CLOJARS_USERNAME=username CLOJARS_PASSWORD=clojars-token clj -X:deploy
-           :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
-                    :exec-fn deps-deploy.deps-deploy/deploy
-                    :exec-args {:installer :remote
-                                #_#_:sign-releases? true
-                                :artifact "target/quil-4.3.1276.jar"}}}}
+            :extra-paths ["target" "test"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -5,10 +5,10 @@
          "target/classes"]
  :resource-paths ["resources"]
  :mvn/repos {"jogl" {:url "https://jogamp.org/deployment/maven/"}}
- :deps {quil/processing-core {:local/root "libraries/core.jar"}
-        quil/processing-dxf {:local/root "libraries/dxf.jar"}
-        quil/processing-pdf {:local/root "libraries/pdf.jar"}
-        quil/processing-svg {:local/root "libraries/svg.jar"}
+ :deps {quil/processing-core {:mvn/version "4.2.3"}
+        quil/processing-dxf {:mvn/version "4.2.3"}
+        quil/processing-pdf {:mvn/version "4.2.3"}
+        quil/processing-svg {:mvn/version "4.2.3"}
 
         ;; native display code
         org.jogamp.gluegen/gluegen-rt {:mvn/version "2.4.0-rc-20230201"}

--- a/project.clj
+++ b/project.clj
@@ -10,12 +10,15 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [quil/processing-core "3.5.3"]
-                 [quil/processing-pdf "3.5.3"]
-                 [quil/processing-dxf "3.5.3"]
-                 [quil/processing-svg "3.5.3"]
+                 [quil/processing-core "4.2.3"]
+                 [quil/processing-pdf "4.2.3"]
+                 [quil/processing-dxf "4.2.3"]
+                 [quil/processing-svg "4.2.3"]
+
+                 ;; FIXME: on clojure-cli these are updated to 2.4.0-rc-20230201
                  [quil/jogl-all-fat "2.3.2"]
                  [quil/gluegen-rt-fat "2.3.2"]
+
                  [cljsjs/p5 "1.7.0-0"]
                  [com.lowagie/itext "2.1.7"
                   :exclusions [bouncycastle/bctsp-jdk14]]


### PR DESCRIPTION
After #401, Processing jars are available on Clojars so this switches to use them instead of local coordinates. As now all dependencies are using remote coordinates instead of local/root, it's possible to use tools.build/write-pom to generate the pom for deploy.  This allows the jar to correctly report it's upstream dependencies.

This also removes some automation steps that were downloading processing before each test or release.