### PR TITLE
Document release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In one swift, skilled motion, Quil throws them both high into the air. In a dust
 
 Quil works with Clojure 1.10 and ClojureScript 1.10.x.
 
-Current released version `4.3.1323` is compatible JDK 17+ and supports Linux amd64,aarch64 and macOS M1/M2/x86_64 architectures.
+Current released version `4.3.1560` is compatible JDK 17+ and supports Linux amd64,aarch64 and macOS M1/M2/x86_64 architectures.
 
 ## Installation
 
@@ -36,13 +36,13 @@ There are also `deps-new` templates available for creating a [sketchbook](https:
 If you like adding libraries manually - you simply need to add Quil as a dependency to `project.clj`:
 
 ```clojure
-[quil "4.3.1323"]
+[quil "4.3.1560"]
 ```
 
 or for Clojure CLI `deps.edn`
 
 ```clojure
-quil/quil {:mvn/version "4.3.1323"}
+quil/quil {:mvn/version "4.3.1560"}
 ```
 
 Then to pull in all of Quil's silky goodness, just add the following to your `ns` declaration:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 4.3.1560
+__21st January 2024__
+
 * Document [release](docs/release.md) process [#409](https://github.com/quil/quil/pull/409)
 * Automatic format check and clj-kondo linting for tests [#408](https://github.com/quil/quil/pull/408)
 * Improve testing documentation [#407](https://github.com/quil/quil/pull/407)

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Document [release](docs/release.md) process [#409](https://github.com/quil/quil/pull/409)
 * Automatic format check and clj-kondo linting for tests [#408](https://github.com/quil/quil/pull/408)
 * Improve testing documentation [#407](https://github.com/quil/quil/pull/407)
 * Exclude JOGL deps from POM for uberjar release [#406](https://github.com/quil/quil/pull/406)

--- a/build.clj
+++ b/build.clj
@@ -42,6 +42,7 @@
                    (format "-%s-SNAPSHOT"
                            (b/git-process {:git-args "rev-parse --short HEAD"}))
                    "")
+        ;; Major/minor prefix should match upstream processing release
         version (format "4.3.%s%s" revs snapshot)]
     (when (:print opts)
       (println "Version:" version))

--- a/build.clj
+++ b/build.clj
@@ -37,12 +37,15 @@
 
   If opts includes :snapshot include git-sha and SNAPSHOT."
   [opts]
-  (format "4.3.%s%s"
-          (b/git-count-revs nil)
-          (if (:snapshot opts)
-            (format "-%s-SNAPSHOT"
-                    (b/git-process {:git-args "rev-parse --short HEAD"}))
-            "")))
+  (let [revs (b/git-count-revs nil)
+        snapshot (if (:snapshot opts)
+                   (format "-%s-SNAPSHOT"
+                           (b/git-process {:git-args "rev-parse --short HEAD"}))
+                   "")
+        version (format "4.3.%s%s" revs snapshot)]
+    (when (:print opts)
+      (println "Version:" version))
+    version))
 
 (defn jar-file [opts]
   (format "target/%s-%s.jar" (name lib) (release-version opts)))

--- a/build/template-pom.xml
+++ b/build/template-pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>quil</groupId>
   <artifactId>quil</artifactId>
-  <version>4.3.1323</version>
+  <version>4.3.1560</version>
   <name>quil</name>
   <licenses>
     <license>
@@ -16,7 +16,7 @@
     <url>https://github.com/quil/quil</url>
     <connection>scm:git:https://github.com/quil/quil.git</connection>
     <developerConnection>scm:git:ssh:git@github.com/quil/quil.git</developerConnection>
-    <tag>v4.3.1323</tag>
+    <tag>v4.3.1560</tag>
   </scm>
   <dependencies>
     <!-- all deps are baked into the jar -->

--- a/docs/release.md
+++ b/docs/release.md
@@ -80,18 +80,20 @@ As they use bindings that verify that JOGL is bundled correctly.
 2. Run all the manual verification steps above
 3. Update `RELEASE-NOTES.md`, to reflect all the changes which went into the current release (including this PR!)
 4. (optional) Consider doing a [snapshot release](https://github.com/quil/quil/actions/workflows/clojars_snapshot_release.yaml), selecting "Run workflow" from branch "master". This will push a snapshot jar to Clojars that can be tested with other projects.
-5. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated. This can also be calculated using: 
+5. Calculate the build version, which incorporates the number of commits to the `master` branch. Remember that this number will be one build higher once the this version commit has been created, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated. If the release includes a changed upstream version for processing, adjust the major/minor component of the `release-version` command in `build.clj` to reflect the upstream version.
+
+The release version for a current commit can be calculated using:
 
 ```
 $ clojure -T:build release-version :print true
 Version: 4.3.1234
 ```
 
-If the release includes a changed upstream version for processing, adjust the major/minor component of the `release-version` command in `build.clj` to reflect the upstream version.
+The build number is also accessible from the github UI showing the latest commit, or using `git rev-list master --count` locally.
 
-6. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`.
-7. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
-8. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
+6. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`. Update `RELEASE-NOTES.md` to show the version/date and start a new unreleased section.
+7. Push, review and merge the release PR
+8. [tag the release](https://github.com/quil/quil/releases/new) by creating a release matching the version tag created above, ie `v4.3.1234` targeted at `master`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
 9. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.
 10. Monitor the [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) to ensure it completes correctly.
 11. Update the lein and deps-new templates to reference the new Clojars release

--- a/docs/release.md
+++ b/docs/release.md
@@ -8,7 +8,7 @@ See also [release-process](https://github.com/quil/quil/wiki/Dev-notes#release-p
 
 Run `lein do check, cljfmt check` and verify that there are no reflection warnings and that everything is formatted.
 
-TODO: automate and include clj-kondo
+TODO: automate and include clj-kondo, and switch to `deps.edn` aliases
 
 ### Run automated tests locally
 
@@ -71,7 +71,7 @@ As they use bindings that verify that JOGL is bundled correctly.
 1. Update `RELEASE-NOTES.md`, to reflect all the changes which went into the current release (including this PR!)
 2. (optional) Consider doing a [snapshot release](https://github.com/quil/quil/actions/workflows/clojars_snapshot_release.yaml), selecting "Run workflow" from branch "master". This will push a snapshot jar to Clojars that can be tested with other projects.
 3. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated.
-4. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references.
+4. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`.
 5. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
 6. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
 7. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,7 +13,7 @@ is only enabled on tests as it has too many failures in `src`.
 
 ### Run automated tests locally
 
-These are run in CI with github actions, but have frequent SEGV flakes, so it's useful to verify locally. See [testing](docs/testing.md) documentation. The minimum to run here is:
+These are run in CI with github actions, but have frequent SEGV flakes, so it's useful to verify locally. See [testing](testing.md) documentation. The minimum to run here is:
 
 ```
 # clj unit and snapshot tests

--- a/docs/release.md
+++ b/docs/release.md
@@ -87,7 +87,7 @@ As they use bindings that verify that JOGL is bundled correctly.
    * https://github.com/quil/quil-examples
    * https://github.com/quil/quil/wiki/Runnable-jar
 
-11. Update quil.info website (optional)
+11. (optional) Update quil.info website. Use [generate docs](https://github.com/quil/quil/wiki/Snippets#generate-documention) steps, but requires permission to update the quil-site page.
 12. Announce the Quil release on [Clojureverse](https://clojureverse.org/), [r/clojure](https://www.reddit.com/r/Clojure/), and the Clojurians slack (both in #announcements and in #quil). Previously this also included clj-processing and clojure google groups.
 
 ### Announcement Template

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,9 +16,12 @@ is only enabled on tests as it has too many failures in `src`.
 These are run in CI with github actions, but have frequent SEGV flakes, so it's useful to verify locally. See [testing](docs/testing.md) documentation. The minimum to run here is:
 
 ```
-$ clojure -M:dev:kaocha unit clj-snippets # clj unit and snapshot tests
-$ clojure -Mfig:cljs-test                 # cljs unit tests
-$ clojure -M:dev:fig:kaocha cljs-snippets # cljs snapshot tests
+# clj unit and snapshot tests
+$ clojure -M:dev:kaocha unit clj-snippets
+# cljs unit tests
+$ clojure -Mfig:cljs-test
+# cljs snapshot tests
+$ clojure -M:dev:fig:kaocha cljs-snippets
 ```
 
 ## Run manual tests
@@ -69,27 +72,25 @@ As they use bindings that verify that JOGL is bundled correctly.
 ## Release Steps
 
 1. Create a new branch for release
-1. Update `RELEASE-NOTES.md`, to reflect all the changes which went into the current release (including this PR!)
-2. (optional) Consider doing a [snapshot release](https://github.com/quil/quil/actions/workflows/clojars_snapshot_release.yaml), selecting "Run workflow" from branch "master". This will push a snapshot jar to Clojars that can be tested with other projects.
-3. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated.
-4. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`.
-5. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
-6. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
-7. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.
-8. Monitor the [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) to ensure it completes correctly.
-9. Update the lein and deps-new templates to reference the new Clojars release
+2. Update `RELEASE-NOTES.md`, to reflect all the changes which went into the current release (including this PR!)
+3. (optional) Consider doing a [snapshot release](https://github.com/quil/quil/actions/workflows/clojars_snapshot_release.yaml), selecting "Run workflow" from branch "master". This will push a snapshot jar to Clojars that can be tested with other projects.
+4. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated.
+5. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`.
+6. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
+7. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
+8. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.
+9. Monitor the [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) to ensure it completes correctly.
+10. Update the lein and deps-new templates to reference the new Clojars release
+    * https://github.com/quil/quil-templates (requires separate release for clj template)
+    * https://github.com/quil/sketchbook-template
+    * https://github.com/quil/clj-sketch-template
 
-   * https://github.com/quil/quil-templates (requires separate release for clj template)
-   * https://github.com/quil/sketchbook-template
-   * https://github.com/quil/clj-sketch-template
+11. Update external references to the release version
+    * https://github.com/quil/quil-examples
+    * https://github.com/quil/quil/wiki/Runnable-jar
 
-10. Update external references to the release version
-
-   * https://github.com/quil/quil-examples
-   * https://github.com/quil/quil/wiki/Runnable-jar
-
-11. (optional) Update quil.info website. Use [generate docs](https://github.com/quil/quil/wiki/Snippets#generate-documention) steps, but requires permission to update the quil-site page.
-12. Announce the Quil release on [Clojureverse](https://clojureverse.org/), [r/clojure](https://www.reddit.com/r/Clojure/), and the Clojurians slack (both in #announcements and in #quil). Previously this also included clj-processing and clojure google groups.
+12. (optional) Update quil.info website. Use [generate docs](https://github.com/quil/quil/wiki/Snippets#generate-documention) steps, but requires permission to update the quil-site page.
+13. Announce the Quil release on [Clojureverse](https://clojureverse.org/), [r/clojure](https://www.reddit.com/r/Clojure/), and the Clojurians slack (both in #announcements and in #quil). Previously this also included clj-processing and clojure google groups.
 
 ### Announcement Template
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,13 +2,15 @@
 
 See also [release-process](https://github.com/quil/quil/wiki/Dev-notes#release-process).
 
-## Check for `cljfmt` and `clj-kondo` warnings
+## Verification
+
+### Check for `cljfmt` and `clj-kondo` warnings
 
 Run `lein do check, cljfmt check` and verify that there are no reflection warnings and that everything is formatted.
 
 TODO: automate and include clj-kondo
 
-## Run automated tests locally
+### Run automated tests locally
 
 These are run in CI with github actions, but have frequent SEGV flakes, so it's useful to verify locally. See [testing](docs/testing.md) documentation. The minimum to run here is:
 
@@ -32,7 +34,7 @@ It may make sense to re-run the "automated" tests here with multiple browsers, a
 $ clj -M:dev:fig:server -b dev -s
 ```
 
-## Verify a snapshot JAR works with quil-examples
+### Verify a snapshot JAR works with quil-examples
 
 The release process creates an uberjar with JOGL and other dependencies bundled inside of it. However, in case the pom references JOGL deps from the upstream repository, or somehow the uberjar fails to bundle them into the jar, it's helpful to checkout `quil-examples` and change it to reference a snapshot uberjar of the current revision.
 
@@ -62,3 +64,28 @@ clj -M -m quil-sketches.gen-art.28-cloud-cube
 ```
 
 As they use bindings that verify that JOGL is bundled correctly.
+
+## Release Steps
+
+1. Create a new branch for release
+1. Update `RELEASE-NOTES.md`, to reflect all the changes which went into the current release (including this PR!)
+2. (optional) Consider doing a [snapshot release](https://github.com/quil/quil/actions/workflows/clojars_snapshot_release.yaml), selecting "Run workflow" from branch "master". This will push a snapshot jar to Clojars that can be tested with other projects.
+3. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated.
+4. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references.
+5. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
+6. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
+7. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.
+8. Monitor the [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) to ensure it completes correctly.
+9. Update the lein and deps-new templates to reference the new Clojars release
+
+   * https://github.com/quil/quil-templates (requires separate release for clj template)
+   * https://github.com/quil/sketchbook-template
+   * https://github.com/quil/clj-sketch-template
+
+10. Update external references to the release version
+
+   * https://github.com/quil/quil-examples
+   * https://github.com/quil/quil/wiki/Runnable-jar
+
+11. Update quil.info website (optional)
+12. Announce the Quil release on [Clojureverse](https://clojureverse.org/), [r/clojure](https://www.reddit.com/r/Clojure/), and the Clojurians slack (both in #announcements and in #quil).

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,9 +6,10 @@ See also [release-process](https://github.com/quil/quil/wiki/Dev-notes#release-p
 
 ### Check for `cljfmt` and `clj-kondo` warnings
 
-Run `lein do check, cljfmt check` and verify that there are no reflection warnings and that everything is formatted.
+Run `bin/lint` and verify that there are no reflection warnings and that everything is formatted.
 
-TODO: automate and include clj-kondo, and switch to `deps.edn` aliases
+This is automated with github actions, however, for now the `clj-kondo` linting
+is only enabled on tests as it has too many failures in `src`.
 
 ### Run automated tests locally
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -88,4 +88,23 @@ As they use bindings that verify that JOGL is bundled correctly.
    * https://github.com/quil/quil/wiki/Runnable-jar
 
 11. Update quil.info website (optional)
-12. Announce the Quil release on [Clojureverse](https://clojureverse.org/), [r/clojure](https://www.reddit.com/r/Clojure/), and the Clojurians slack (both in #announcements and in #quil).
+12. Announce the Quil release on [Clojureverse](https://clojureverse.org/), [r/clojure](https://www.reddit.com/r/Clojure/), and the Clojurians slack (both in #announcements and in #quil). Previously this also included clj-processing and clojure google groups.
+
+### Announcement Template
+
+```
+Subject:
+[ANN] Quil $VERSION Release
+Body:
+Happy to announce Quil v4.3.123 release.
+Quil is a Clojure/ClojureScript library for creating interactive drawings and animations.
+
+The release available on clojars: https://clojars.org/quil. List of changes:
+
+Change 1
+Change 2
+Documentation on http://quil.info has been updated as well.
+
+Happy hacking!
+$YOUR_NAME
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -40,7 +40,7 @@ $ clojure -M:dev:kaocha --no-capture-output manual
 It may make sense to re-run the "automated" tests here with multiple browsers, at the very least Chrome, Firefox, as well as the manual tests covering user input, and canvas resize.
 
 ```
-$ clj -M:dev:fig:server -b dev -s
+$ clojure -M:dev:fig:server -b dev -s
 ```
 
 ### Verify a snapshot JAR works with quil-examples
@@ -50,9 +50,9 @@ The release process creates an uberjar with JOGL and other dependencies bundled 
 The following command will be build a local snapshot of the current revision and install that snapshot to the matching location in the maven `.m2` repository. This can also be accomplished with a snapshot deploy to clojars using the `.github/workflows/clojars_snapshot_release.yaml` process.
 
 ```
-$ clj -T:build release :snapshot true
+$ clojure -T:build release :snapshot true
 release: target/quil-4.3.1508-28b0120-SNAPSHOT.jar (16776.1 kb)
-$ clj -T:build deploy :clojars false :snapshot true
+$ clojure -T:build deploy :clojars false :snapshot true
 Installing quil/quil-4.3.1508-28b0120-SNAPSHOT to your local `.m2`
 done.
 ```
@@ -67,9 +67,9 @@ Then run a few example sketches, particularly ones like:
 
 ```
 # uses opengl renderer
-clj -M -m quil-sketches.gen-art.26-sphere
+clojure -M -m quil-sketches.gen-art.26-sphere
 # uses p3d renderer
-clj -M -m quil-sketches.gen-art.28-cloud-cube
+clojure -M -m quil-sketches.gen-art.28-cloud-cube
 ```
 
 As they use bindings that verify that JOGL is bundled correctly.

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,36 @@
 
 See also [release-process](https://github.com/quil/quil/wiki/Dev-notes#release-process).
 
+## Check for `cljfmt` and `clj-kondo` warnings
+
+Run `lein do check, cljfmt check` and verify that there are no reflection warnings and that everything is formatted.
+
+TODO: automate and include clj-kondo
+
+## Run automated tests locally
+
+These are run in CI with github actions, but have frequent SEGV flakes, so it's useful to verify locally. See [testing](docs/testing.md) documentation. The minimum to run here is:
+
+```
+$ clojure -M:dev:kaocha unit clj-snippets # clj unit and snapshot tests
+$ clojure -Mfig:cljs-test                 # cljs unit tests
+$ clojure -M:dev:fig:kaocha cljs-snippets # cljs snapshot tests
+```
+
+## Run manual tests
+
+These tests ensure that user input through mouse or keyboard and resizing the canvas all work correctly.
+
+```
+$ clojure -M:dev:kaocha --no-capture-output manual
+```
+
+It may make sense to re-run the "automated" tests here with multiple browsers, at the very least Chrome, Firefox, as well as the manual tests covering user input, and canvas resize.
+
+```
+$ clj -M:dev:fig:server -b dev -s
+```
+
 ## Verify a snapshot JAR works with quil-examples
 
 The release process creates an uberjar with JOGL and other dependencies bundled inside of it. However, in case the pom references JOGL deps from the upstream repository, or somehow the uberjar fails to bundle them into the jar, it's helpful to checkout `quil-examples` and change it to reference a snapshot uberjar of the current revision.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,11 @@
 # Release
 
-See also [release-process](https://github.com/quil/quil/wiki/Dev-notes#release-process).
+Process notes and explanation on how to release a new version of Quil using the automated tooling.
+
+1. Verify the build is ready
+2. Release!
+
+Adapted from the [release-process](https://github.com/quil/quil/wiki/Dev-notes#release-process) notes.
 
 ## Verification
 
@@ -72,25 +77,26 @@ As they use bindings that verify that JOGL is bundled correctly.
 ## Release Steps
 
 1. Create a new branch for release
-2. Update `RELEASE-NOTES.md`, to reflect all the changes which went into the current release (including this PR!)
-3. (optional) Consider doing a [snapshot release](https://github.com/quil/quil/actions/workflows/clojars_snapshot_release.yaml), selecting "Run workflow" from branch "master". This will push a snapshot jar to Clojars that can be tested with other projects.
-4. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated.
-5. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`.
-6. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
-7. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
-8. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.
-9. Monitor the [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) to ensure it completes correctly.
-10. Update the lein and deps-new templates to reference the new Clojars release
+2. Run all the manual verification steps above
+3. Update `RELEASE-NOTES.md`, to reflect all the changes which went into the current release (including this PR!)
+4. (optional) Consider doing a [snapshot release](https://github.com/quil/quil/actions/workflows/clojars_snapshot_release.yaml), selecting "Run workflow" from branch "master". This will push a snapshot jar to Clojars that can be tested with other projects.
+5. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated.
+6. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`.
+7. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
+8. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
+9. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.
+10. Monitor the [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) to ensure it completes correctly.
+11. Update the lein and deps-new templates to reference the new Clojars release
     * https://github.com/quil/quil-templates (requires separate release for clj template)
     * https://github.com/quil/sketchbook-template
     * https://github.com/quil/clj-sketch-template
 
-11. Update external references to the release version
+12. Update external references to the release version
     * https://github.com/quil/quil-examples
     * https://github.com/quil/quil/wiki/Runnable-jar
 
-12. (optional) Update quil.info website. Use [generate docs](https://github.com/quil/quil/wiki/Snippets#generate-documention) steps, but requires permission to update the quil-site page.
-13. Announce the Quil release on [Clojureverse](https://clojureverse.org/), [r/clojure](https://www.reddit.com/r/Clojure/), and the Clojurians slack (both in #announcements and in #quil). Previously this also included clj-processing and clojure google groups.
+13. (optional) Update quil.info website. Use [generate docs](https://github.com/quil/quil/wiki/Snippets#generate-documention) steps, but requires permission to update the quil-site page.
+14. Announce the Quil release on [Clojureverse](https://clojureverse.org/), [r/clojure](https://www.reddit.com/r/Clojure/), and the Clojurians slack (both in #announcements and in #quil). Previously this also included clj-processing and clojure google groups.
 
 ### Announcement Template
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -80,7 +80,13 @@ As they use bindings that verify that JOGL is bundled correctly.
 2. Run all the manual verification steps above
 3. Update `RELEASE-NOTES.md`, to reflect all the changes which went into the current release (including this PR!)
 4. (optional) Consider doing a [snapshot release](https://github.com/quil/quil/actions/workflows/clojars_snapshot_release.yaml), selecting "Run workflow" from branch "master". This will push a snapshot jar to Clojars that can be tested with other projects.
-5. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated.
+5. Calculate the build version, which incorporates the number of commits to the `master` branch. Either read it from the github UI showing the latest commit, or use `git rev-list master --count` locally. Remember that since there are locally committed changes this number will likely be higher once the commits are pushed to github or the PR is merged, so adjust accordingly. The release should be in form of `v4.3.1234` where `4.3` tracks the upstream processing release version, and `1234` is the build number just calculated. This can also be calculated using: 
+
+```
+$ clojure -T:build release-version :print true
+Version: 4.3.1234
+```
+
 6. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`.
 7. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
 8. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.

--- a/docs/release.md
+++ b/docs/release.md
@@ -87,6 +87,8 @@ $ clojure -T:build release-version :print true
 Version: 4.3.1234
 ```
 
+If the release includes a changed upstream version for processing, adjust the major/minor component of the `release-version` command in `build.clj` to reflect the upstream version.
+
 6. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`.
 7. Push, review, and merge the release PR, making sure the version matches the build count of the merged PR.
 8. [tag a release](https://github.com/quil/quil/releases/new) by creating a new tag matching the version above, ie `v4.3.1234`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.

--- a/docs/release.md
+++ b/docs/release.md
@@ -67,9 +67,9 @@ Then run a few example sketches, particularly ones like:
 
 ```
 # uses opengl renderer
-clojure -M -m quil-sketches.gen-art.26-sphere
+$ clojure -M -m quil-sketches.gen-art.26-sphere
 # uses p3d renderer
-clojure -M -m quil-sketches.gen-art.28-cloud-cube
+$ clojure -M -m quil-sketches.gen-art.28-cloud-cube
 ```
 
 As they use bindings that verify that JOGL is bundled correctly.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject quil "4.3.1323"
+(defproject quil "4.3.1560"
   :description "(mix Processing Clojure)"
   :url "http://github.com/quil/quil"
 


### PR DESCRIPTION
Updates `docs` folder documentation to cover the new release process. Haven't deprecated the associated wiki pages for this but found it helpful to update this inline so it can be searched when scanning the repo instead of in the separate wiki.