### PR TITLE
Fix 1560/1561 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ There are also `deps-new` templates available for creating a [sketchbook](https:
 If you like adding libraries manually - you simply need to add Quil as a dependency to `project.clj`:
 
 ```clojure
-[quil "4.3.1560"]
+[quil "4.3.1563"]
 ```
 
 or for Clojure CLI `deps.edn`
 
 ```clojure
-quil/quil {:mvn/version "4.3.1560"}
+quil/quil {:mvn/version "4.3.1563"}
 ```
 
 Then to pull in all of Quil's silky goodness, just add the following to your `ns` declaration:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 4.3.1560
+## 4.3.1563
 __21st January 2024__
 
 * Document [release](docs/release.md) process [#409](https://github.com/quil/quil/pull/409)

--- a/build/template-pom.xml
+++ b/build/template-pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>quil</groupId>
   <artifactId>quil</artifactId>
-  <version>4.3.1560</version>
+  <version>4.3.1563</version>
   <name>quil</name>
   <licenses>
     <license>
@@ -16,7 +16,7 @@
     <url>https://github.com/quil/quil</url>
     <connection>scm:git:https://github.com/quil/quil.git</connection>
     <developerConnection>scm:git:ssh:git@github.com/quil/quil.git</developerConnection>
-    <tag>v4.3.1560</tag>
+    <tag>v4.3.1563</tag>
   </scm>
   <dependencies>
     <!-- all deps are baked into the jar -->

--- a/docs/release.md
+++ b/docs/release.md
@@ -92,10 +92,10 @@ Version: 4.3.1234
 The build number is also accessible from the github UI showing the latest commit, or using `git rev-list master --count` locally.
 
 6. Update Quil version in the `README.md`, for `deps.edn` and Leiningen coordinates, and any other references. Update version in `project.clj`. Update `RELEASE-NOTES.md` to show the version/date and start a new unreleased section.
-7. Push, review and merge the release PR
-8. [tag the release](https://github.com/quil/quil/releases/new) by creating a release matching the version tag created above, ie `v4.3.1234` targeted at `master`. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
-9. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.
-10. Monitor the [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) to ensure it completes correctly.
+7. Push, review, and wait for tests to pass and then [tag the release](https://github.com/quil/quil/releases/new) by creating a release matching the version tag created above, ie `v4.3.1234` targeted at the head of the PR branch. Select the previous release and use generate release notes and adjust that text for the release. Leave `set as the latest release` checked.
+8. Click `Publish release`. The [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) is configured to upload a JAR to Clojars whenever a tag is created starting with `v`. This will upload a jar to Clojars versioned as the release version ie `v4.3.1234`.
+9. Monitor the [release action](https://github.com/quil/quil/actions/workflows/clojars_release.yaml) to ensure it completes correctly.
+10. Merge the release PR
 11. Update the lein and deps-new templates to reference the new Clojars release
     * https://github.com/quil/quil-templates (requires separate release for clj template)
     * https://github.com/quil/sketchbook-template

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject quil "4.3.1560"
+(defproject quil "4.3.1563"
   :description "(mix Processing Clojure)"
   :url "http://github.com/quil/quil"
 


### PR DESCRIPTION
Accidentally tagged the PR merge instead of the head of the branch for releasing v4.3.1560. As a result, while everything was labeled v4.3.1560, the machinery calculated the build number including the PR merge and thus created a jar for v4.3.1561. 

I deleted the v4.3.1560 release tag and release info as it had no corresponding jar, but I can't remove it from Clojars, so in the effort to ensure that semver will use incrementing numbers, I'm re-releasing with just a minor documentation fix and ensuring the release versions match the jar version on Clojars.