### PR TITLE
Processing 4.4

### DIFF
--- a/.github/workflows/clojars_release.yaml
+++ b/.github/workflows/clojars_release.yaml
@@ -26,7 +26,7 @@ jobs:
           java-version: 17
 
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@12.2
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
           bb: latest

--- a/.github/workflows/clojars_snapshot_release.yaml
+++ b/.github/workflows/clojars_snapshot_release.yaml
@@ -24,7 +24,7 @@ jobs:
           java-version: 17
 
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@12.2
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
           bb: latest

--- a/.github/workflows/publish_processing.yaml
+++ b/.github/workflows/publish_processing.yaml
@@ -24,7 +24,7 @@ jobs:
           java-version: 17
 
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@12.2
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
           bb: latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache deps.edn dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache deps.edn dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Test
         uses: coactions/setup-xvfb@v1
+        timeout-minutes: 3
         with:
           run: clojure -Mfig:cljs-test
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,15 +55,11 @@ jobs:
         run: bin/lint
 
       - name: Test
-        uses: coactions/setup-xvfb@v1
         timeout-minutes: 3
-        with:
-          run: clojure -Mfig:cljs-test
+        run: xvfb-run --server-args="-screen 0 1600x1200x24" clojure -Mfig:cljs-test
 
       - name: Test CLJS Snippet Snapshots
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: clojure -M:dev:fig:kaocha cljs-snippets
+        run: xvfb-run --server-args="-screen 0 1600x1200x24" clojure -M:dev:fig:kaocha cljs-snippets
 
       - name: Upload Test Artifacts
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,9 @@ jobs:
           cli: latest
           bb: latest
 
+      - name: Setup ImageMagick
+        uses: mfinelli/setup-imagemagick@v6
+
       - name: System Info
         run: bb system-info
 
@@ -113,6 +116,9 @@ jobs:
         with:
           cli: latest
           bb: latest
+
+      - name: Setup ImageMagick
+        uses: mfinelli/setup-imagemagick@v6
 
       - name: System Info
         run: bb system-info

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Test
         timeout-minutes: 5
         run: |
-          ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:kaocha --no-capture-output --reporter doc unit clj-snippets
+          ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:kaocha --no-capture-output- -reporter doc unit clj-snippets
 
       - name: Upload Test Artifacts
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,8 +117,7 @@ jobs:
           cli: latest
           bb: latest
 
-      - name: Setup ImageMagick
-        uses: mfinelli/setup-imagemagick@v6
+      - uses: mfinelli/setup-imagemagick@v6
 
       - name: System Info
         run: bb system-info

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Test
         timeout-minutes: 5
         run: |
-          ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:kaocha --reporter doc unit clj-snippets
+          ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:kaocha --no-capture-output --reporter doc unit clj-snippets
 
       - name: Upload Test Artifacts
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -124,10 +124,9 @@ jobs:
       # Ie all the tests including snippet tests, many of which are also
       # verified from a CLJS context.
       - name: Test
-        uses: coactions/setup-xvfb@v1
         timeout-minutes: 5
-        with:
-          run: clojure -M:dev:kaocha --reporter doc unit clj-snippets
+        run: |
+          ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:kaocha --reporter doc unit clj-snippets
 
       - name: Upload Test Artifacts
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -131,7 +131,7 @@ jobs:
       - name: Test
         timeout-minutes: 5
         run: |
-          ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:kaocha --no-capture-output- -reporter doc unit clj-snippets
+          ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:kaocha --no-capture-output --reporter doc unit clj-snippets
 
       - name: Upload Test Artifacts
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,8 +61,9 @@ jobs:
         timeout-minutes: 3
         run: clojure -Mfig:cljs-test
 
+      # xvfb-run needed so that pixel density be determine which reference images to use
       - name: Test CLJS Snippet Snapshots
-        run: clojure -M:dev:fig:kaocha cljs-snippets
+        run: ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:fig:kaocha cljs-snippets
 
       - name: Upload Test Artifacts
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
           java-version: 17
 
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@12.2
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
           bb: latest
@@ -112,7 +112,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
 
       - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@12.2
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           cli: latest
           bb: latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,10 +56,10 @@ jobs:
 
       - name: Test
         timeout-minutes: 3
-        run: xvfb-run --server-args="-screen 0 1600x1200x24" clojure -Mfig:cljs-test
+        run: clojure -Mfig:cljs-test
 
       - name: Test CLJS Snippet Snapshots
-        run: xvfb-run --server-args="-screen 0 1600x1200x24" clojure -M:dev:fig:kaocha cljs-snippets
+        run: clojure -M:dev:fig:kaocha cljs-snippets
 
       - name: Upload Test Artifacts
         if: failure()

--- a/deps.edn
+++ b/deps.edn
@@ -14,8 +14,8 @@
 
            :dev
            {:extra-deps {;; for snippet tests
-                         clj-http/clj-http {:mvn/version "3.12.3"}
-                         etaoin/etaoin {:mvn/version "1.0.40"}
+                         clj-http/clj-http {:mvn/version "3.13.1"}
+                         etaoin/etaoin {:mvn/version "1.1.43"}
 
                          ;; for fn-metas tests
                          cheshire/cheshire {:mvn/version "5.12.0"}
@@ -31,8 +31,8 @@
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}
 
                                ;; for CLJS snippet tests
-                               clj-http/clj-http {:mvn/version "3.12.3"}
-                               etaoin/etaoin {:mvn/version "1.0.40"}
+                               clj-http/clj-http {:mvn/version "3.13.1"}
+                               etaoin/etaoin {:mvn/version "1.1.43"}
                                }
                   :main-opts ["-m" "cognitect.test-runner"]
                   :exec-fn cognitect.test-runner.api/test}

--- a/deps.edn
+++ b/deps.edn
@@ -61,7 +61,7 @@
 
            ;; clj -M:clj-kondo --lint src test
            :clj-kondo
-           {:deps {clj-kondo/clj-kondo {:mvn/version "2023.12.15"}}
+           {:deps {clj-kondo/clj-kondo {:mvn/version "2025.06.05"}}
             :main-opts ["-m" "clj-kondo.main"]}
 
            ;; clj -M:format check

--- a/deps.edn
+++ b/deps.edn
@@ -20,6 +20,9 @@
                          ;; for fn-metas tests
                          cheshire/cheshire {:mvn/version "6.0.0"}
 
+                         ;; logging implementation so that we see logs
+                         org.slf4j/slf4j-simple {:mvn/version "2.0.12"}
+
                          ;; for cljs manual tests
                          compojure/compojure {:mvn/version "1.7.0"}
                          hiccup/hiccup {:mvn/version "1.0.5"}}

--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,24 @@
  :resource-paths ["resources"]
  :mvn/repos {"jogl" {:url "https://jogamp.org/deployment/maven/"}}
  :deps {org.processing/core {:mvn/version "4.4.4"}
+        ;; FIXME: switch to org.processing/{dxf,pdf,svg} when released. For now
+        ;; we can fallback to the previous quil releases as these are compatable
+        ;; with 4.4.4. itext, bctsp and batik dependencies should also go away
+        ;; once processing releases maven hosted svg and pdf libraries.
+        quil/processing-dxf {:mvn/version "4.2.3"}
+        quil/processing-pdf {:mvn/version "4.2.3"}
+        quil/processing-svg {:mvn/version "4.2.3"}
+        ;; part of PDF support
+        ;; version defined by processing in https://github.com/benfry/processing4/tree/main/java/libraries/pdf
+        ;; see also https://github.com/quil/quil/issues/247
+        com.lowagie/itext {:mvn/version "2.1.7"
+                           :exclusions [bouncycastle/bctsp-jdk14]}
+        org.bouncycastle/bctsp-jdk14 {:mvn/version "1.38"}
+        ;; svg export
+        ;; versions from https://github.com/benfry/processing4/blob/main/java/libraries/svg/build.xml#L6
+        org.apache.xmlgraphics/batik-svggen {:mvn/version "1.14"}
+        org.apache.xmlgraphics/batik-dom {:mvn/version "1.14"}
+
         ;; clojurescript p5js
         cljsjs/p5 {:mvn/version "1.7.0-0"}}
  :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.9" :git/sha "e405aac"}

--- a/deps.edn
+++ b/deps.edn
@@ -40,7 +40,7 @@
            ;; clj -M:dev:kaocha
            :kaocha
            {:main-opts ["-m" "kaocha.runner"]
-            :extra-deps {lambdaisland/kaocha {:mvn/version "1.87.1366"}}}
+            :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}}
 
            :fig
            {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.60"}

--- a/deps.edn
+++ b/deps.edn
@@ -65,7 +65,7 @@
 
            :fig
            {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.60"}
-                         fipp/fipp {:mvn/version "0.6.26"} ;; better diff output
+                         fipp/fipp {:mvn/version "0.6.27"} ;; better diff output
                          prismatic/dommy {:mvn/version "1.1.0"}
                          com.bhauman/rebel-readline-cljs {:mvn/version "0.1.5"}
                          com.bhauman/figwheel-main {:mvn/version "0.2.20"}}

--- a/deps.edn
+++ b/deps.edn
@@ -46,8 +46,8 @@
            {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.60"}
                          fipp/fipp {:mvn/version "0.6.26"} ;; better diff output
                          prismatic/dommy {:mvn/version "1.1.0"}
-                         com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
-                         com.bhauman/figwheel-main {:mvn/version "0.2.18"}}
+                         com.bhauman/rebel-readline-cljs {:mvn/version "0.1.5"}
+                         com.bhauman/figwheel-main {:mvn/version "0.2.20"}}
             :extra-paths ["target" "test/cljs"]}
 
            ;; clj -Mfig:cljs-test

--- a/deps.edn
+++ b/deps.edn
@@ -42,8 +42,8 @@
                          org.slf4j/slf4j-simple {:mvn/version "2.0.17"}
 
                          ;; for cljs manual tests
-                         compojure/compojure {:mvn/version "1.7.0"}
-                         hiccup/hiccup {:mvn/version "1.0.5"}}
+                         compojure/compojure {:mvn/version "1.7.1"}
+                         hiccup/hiccup {:mvn/version "2.0.0"}}
             :extra-paths ["test" "dev-resources"]}
 
            ;; clj -X:test

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,7 @@
                          etaoin/etaoin {:mvn/version "1.1.43"}
 
                          ;; for fn-metas tests
-                         cheshire/cheshire {:mvn/version "5.12.0"}
+                         cheshire/cheshire {:mvn/version "6.0.0"}
 
                          ;; for cljs manual tests
                          compojure/compojure {:mvn/version "1.7.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
  :deps {org.processing/core {:mvn/version "4.4.4"}
         ;; clojurescript p5js
         cljsjs/p5 {:mvn/version "1.7.0-0"}}
- :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.6" :git/sha "8e78bcc"}
+ :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.9" :git/sha "e405aac"}
                           slipset/deps-deploy {:mvn/version "RELEASE"}}
                    :ns-default build}
 

--- a/deps.edn
+++ b/deps.edn
@@ -39,7 +39,7 @@
                          cheshire/cheshire {:mvn/version "6.0.0"}
 
                          ;; logging implementation so that we see logs
-                         org.slf4j/slf4j-simple {:mvn/version "2.0.12"}
+                         org.slf4j/slf4j-simple {:mvn/version "2.0.17"}
 
                          ;; for cljs manual tests
                          compojure/compojure {:mvn/version "1.7.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -5,37 +5,7 @@
          "target/classes"]
  :resource-paths ["resources"]
  :mvn/repos {"jogl" {:url "https://jogamp.org/deployment/maven/"}}
- :deps {quil/processing-core {:mvn/version "4.2.3"}
-        quil/processing-dxf {:mvn/version "4.2.3"}
-        quil/processing-pdf {:mvn/version "4.2.3"}
-        quil/processing-svg {:mvn/version "4.2.3"}
-
-        ;; native display code
-        org.jogamp.gluegen/gluegen-rt {:mvn/version "2.4.0-rc-20230201"}
-        org.jogamp.gluegen/gluegen-rt$natives-macosx-universal {:mvn/version "2.4.0-rc-20230201"}
-        org.jogamp.gluegen/gluegen-rt$natives-linux-amd64 {:mvn/version "2.4.0-rc-20230201"}
-        org.jogamp.gluegen/gluegen-rt$natives-linux-aarch64 {:mvn/version "2.4.0-rc-20230201"}
-        org.jogamp.gluegen/gluegen-rt$natives-windows-amd64 {:mvn/version "2.4.0-rc-20230201"}
-
-        org.jogamp.jogl/jogl-all {:mvn/version "2.4.0-rc-20230201"}
-        org.jogamp.jogl/jogl-all$natives-macosx-universal {:mvn/version "2.4.0-rc-20230201"}
-        org.jogamp.jogl/jogl-all$natives-linux-amd64 {:mvn/version "2.4.0-rc-20230201"}
-        org.jogamp.jogl/jogl-all$natives-linux-aarch64 {:mvn/version "2.4.0-rc-20230201"}
-        org.jogamp.jogl/jogl-all$natives-windows-amd64 {:mvn/version "2.4.0-rc-20230201"}
-
-        ;; part of PDF support
-        ;; version defined by processing in https://github.com/benfry/processing4/tree/main/java/libraries/pdf
-        ;; see also https://github.com/quil/quil/issues/247
-        com.lowagie/itext {:mvn/version "2.1.7"
-                           :exclusions [bouncycastle/bctsp-jdk14]}
-        org.bouncycastle/bctsp-jdk14 {:mvn/version "1.38"}
-
-        ;; svg export
-        ;; versions from https://github.com/benfry/processing4/blob/main/java/libraries/svg/build.xml#L6
-        ;; FIXME: push this dependency to processing-svg?
-        org.apache.xmlgraphics/batik-svggen {:mvn/version "1.14"}
-        org.apache.xmlgraphics/batik-dom {:mvn/version "1.14"}
-
+ :deps {org.processing/core {:mvn/version "4.4.4"}
         ;; clojurescript p5js
         cljsjs/p5 {:mvn/version "1.7.0-0"}}
  :aliases {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.6" :git/sha "8e78bcc"}

--- a/src/bb/system_info.clj
+++ b/src/bb/system_info.clj
@@ -11,4 +11,9 @@
   (bp/shell "bb" "version")
   (when-not (= (System/getenv "RUNNER_OS") "Windows")
     (println "$ clojure -version")
-    (bp/shell "clojure" "-version")))
+    (bp/shell "clojure" "-version"))
+
+  ;; imagemagick utilities for image compare
+  (doseq [pname ["compare" "convert" "identify"]]
+    (println "$" pname "-version")
+    (bp/shell (str pname " -version"))))

--- a/src/bb/system_info.clj
+++ b/src/bb/system_info.clj
@@ -1,5 +1,6 @@
 (ns bb.system-info
   (:require
+   [babashka.fs :as fs]
    [babashka.process :as bp]))
 
 (defn versions []
@@ -13,7 +14,11 @@
     (println "$ clojure -version")
     (bp/shell "clojure" "-version"))
 
-  ;; imagemagick utilities for image compare
-  (doseq [pname ["compare" "convert" "identify"]]
-    (println "$" pname "-version")
-    (bp/shell (str pname " -version"))))
+  (if (fs/which "magick")
+    (do (println "$ magick -version")
+        (bp/shell "magick" "-version"))
+
+    ;; imagemagick utilities for image compare
+    (doseq [pname ["compare" "convert" "identify"]]
+      (println "$" pname "-version")
+      (bp/shell (str pname " -version")))))

--- a/src/cljc/quil/snippets/image/pixels.cljc
+++ b/src/cljc/quil/snippets/image/pixels.cljc
@@ -103,6 +103,9 @@
 
   (q/no-loop))
 
+;; FIXME: Throwing error:
+;; http://localhost:3000/js/main.js 13:611915 Uncaught TypeError: t is not a function
+;; Best guess is one of the filter modes is not a function?
 (defsnippet display-filter
   "display-filter"
   ;; FIXME: increasing threshold in CLJS as it's not currently working. Will

--- a/test.cljs.edn
+++ b/test.cljs.edn
@@ -3,7 +3,7 @@
   :log-level :all
   :client-log-level :finest
   ;; headless is hanging?
-  ;; :launch-js ["google-chrome" "--headless" "--repl" "--disable-gpu" :open-url]
+  :launch-js ["google-chrome" "--headless" "--disable-dev-shm" "--disable-gpu" "--remote-debugging-port=9222" "--disable-gpu" "--repl" :open-url]
   ;; :launch-js ["firefox" :open-url]
   }
 

--- a/test/quil/snippets/browser_snapshot_test.clj
+++ b/test/quil/snippets/browser_snapshot_test.clj
@@ -91,8 +91,8 @@
         (sth/verify-reference-or-update
          name "cljs" actual-file accepted-diff-threshold)
         ;; disable for now, as lots of chatty logging, but useful to inspect
-        #_(t/is (empty? (etaoin/get-logs @driver))
-                (str "logs from " name " - " index))
+        ;; (t/is (empty? (etaoin/get-logs @driver))
+        ;;       (str "logs from " name " - " index))
         ))))
 
 ;; view image diffs with

--- a/test/quil/snippets/browser_snapshot_test.clj
+++ b/test/quil/snippets/browser_snapshot_test.clj
@@ -82,6 +82,7 @@
   all-cljs-snippets-produce-expected-output
   (etaoin/go @driver "http://localhost:3000/test.html")
   (let [elements (snippet-elements @driver)]
+    (println (format "Generating %d browser snippet tests" (count elements)))
     (t/is (seq elements) "unable to find tests on test.html harness")
     (doseq [{:keys [name index accepted-diff-threshold]} elements]
       (etaoin/go @driver (str "http://localhost:3000/test.html#" index))

--- a/test/quil/snippets/browser_snapshot_test.clj
+++ b/test/quil/snippets/browser_snapshot_test.clj
@@ -42,7 +42,9 @@
 (defn etaoin-setup [f]
   (t/is (test-file-server-running?)
         (str "Seems like file server with test page is not running. "))
-  (let [browser (etaoin/chrome {:size [1280 1024]})]
+  (let [browser (etaoin/chrome {:size [1280 1024]
+                                :headless true
+                                :log-level :all})]
     (reset! driver browser)
     (try (f)
          (finally

--- a/test/quil/snippets/browser_snapshot_test.clj
+++ b/test/quil/snippets/browser_snapshot_test.clj
@@ -44,7 +44,9 @@
         (str "Seems like file server with test page is not running. "))
   (let [browser (etaoin/chrome {:size [1280 1024]
                                 :headless true
-                                :log-level :all})]
+                                :args ["--enable-unsafe-swiftshader"]
+                                :log-level :severe ;; :all, :warning
+                                })]
     (reset! driver browser)
     (try (f)
          (finally
@@ -89,7 +91,8 @@
         (sth/verify-reference-or-update
          name "cljs" actual-file accepted-diff-threshold)
         ;; disable for now, as lots of chatty logging, but useful to inspect
-        ;; (t/is (empty? (etaoin/get-logs @driver)))
+        #_(t/is (empty? (etaoin/get-logs @driver))
+                (str "logs from " name " - " index))
         ))))
 
 ;; view image diffs with

--- a/test/quil/snippets/browser_snapshot_test.clj
+++ b/test/quil/snippets/browser_snapshot_test.clj
@@ -8,11 +8,11 @@
 
 ;; geckodriver is producing 625x625 images for actuals vs 500x500 for reference
 (defn- geckodriver-installed? []
-  (sth/installed? "geckodriver" "--version"))
+  (sth/installed? "geckodriver"))
 
 ;; download driver from https://googlechromelabs.github.io/chrome-for-testing/
 (defn- chromedriver-installed? []
-  (sth/installed? "chromedriver" "--version"))
+  (sth/installed? "chromedriver"))
 
 (defn- test-file-server-running? []
   (try

--- a/test/quil/snippets/fn_metas_test.clj
+++ b/test/quil/snippets/fn_metas_test.clj
@@ -47,6 +47,8 @@
   (->> (get item "itemtype")
        (contains? #{"method" "property"})))
 
+;; FIXME: slow test because of http fetch/json parse
+;; can we cache this safely somehow?
 (defn p5js-method-names []
   (let [items (-> (http/get "https://p5js.org/reference/data.json")
                   :body

--- a/test/quil/snippets/fn_metas_test.clj
+++ b/test/quil/snippets/fn_metas_test.clj
@@ -48,7 +48,7 @@
        (contains? #{"method" "property"})))
 
 (defn p5js-method-names []
-  (let [items (-> (http/get "https://p5js.org/reference/data.min.json")
+  (let [items (-> (http/get "https://p5js.org/reference/data.json")
                   :body
                   (json/parse-string)
                   (get "classitems"))

--- a/test/quil/snippets/snapshot_test.clj
+++ b/test/quil/snippets/snapshot_test.clj
@@ -81,6 +81,8 @@
                :renderer (:renderer opts :java2d)
                :draw body)))))
 
+(println (format "Generating %d snippets" (count as/all-snippets)))
+
 (doseq [snippet as/all-snippets]
   (define-snippet-as-test snippet))
 

--- a/test/quil/snippets/test_helper.clj
+++ b/test/quil/snippets/test_helper.clj
@@ -100,6 +100,4 @@
            (installed? "convert" "-version")
            (installed? "identify" "-version"))
     (f)
-    (do
-      (println "Imagemagick not detected. Please install it for automated image comparison to work.")
-      false)))
+    (throw (ex-info "Imagemagick not detected. Please install it for automated image comparison to work." {}))))

--- a/test/quil/snippets/test_helper.clj
+++ b/test/quil/snippets/test_helper.clj
@@ -34,6 +34,21 @@
        test-name
        "-difference.png"))
 
+(defn installed? [& cmds]
+  (try
+    (apply sh/sh cmds)
+    true
+    (catch java.io.IOException _e false)))
+
+;; imagemagick7 prepends identify, convert, compare with the magick command
+(def magick7-installed?
+  (some? (installed? "magick" "-version")))
+
+(defn magick [& args]
+  (if magick7-installed?
+    (apply sh/sh (cons "magick" args))
+    (apply sh/sh args)))
+
 (defn compare-images
   "Compares images at file paths `expected` and `actual` and produces another
   image at path `difference` which highlights any differences in the images.
@@ -44,7 +59,7 @@
   [expected actual difference]
   ;; use imagemagick compare executable for comparison
   ;; see https://imagemagick.org/script/compare.php
-  (let [{:keys [err]} (sh/sh "compare" "-metric" "mae" expected actual difference)
+  (let [{:keys [err]} (magick "compare" "-metric" "mae" expected actual difference)
         result        (second (re-find #"\((.*)\)" err))]
     (if result
       (Double/parseDouble result)
@@ -57,19 +72,19 @@
         diff-file (diff-image platform test-name)
         result (compare-images expected-file actual-file diff-file)
         ;; identify output to verify image sizes are equivalent
-        identify (:out (sh/sh "identify" actual-file expected-file))]
+        identify (:out (magick "identify" actual-file expected-file))]
     (when (number? result)
       (if (<= result threshold)
         (do
           (io/delete-file (io/file actual-file))
           (io/delete-file (io/file diff-file)))
         ;; add actual and expected images to difference image for easier comparison
-        (sh/sh "convert"
-               actual-file
-               diff-file
-               expected-file
-               "+append"
-               diff-file))
+        (magick "convert"
+                actual-file
+                diff-file
+                expected-file
+                "+append"
+                diff-file))
       (t/is (<= result threshold)
             (str "Image differences in \"" test-name "\", see: " diff-file "\n"
                  identify)))))
@@ -89,15 +104,10 @@
       (.renameTo (io/file actual-file) (io/file expected)))
     (assert-match-reference! test-name platform actual-file threshold)))
 
-(defn installed? [& cmds]
-  (try
-    (apply sh/sh cmds)
-    true
-    (catch java.io.IOException _e false)))
-
 (defn imagemagick-installed [f]
-  (if (and (installed? "compare" "-version")
-           (installed? "convert" "-version")
-           (installed? "identify" "-version"))
+  (if (or (installed? "magick" "-version")
+          (and (installed? "compare" "-version")
+               (installed? "convert" "-version")
+               (installed? "identify" "-version")))
     (f)
     (throw (ex-info "Imagemagick not detected. Please install it for automated image comparison to work." {}))))

--- a/test/quil/snippets/test_helper.clj
+++ b/test/quil/snippets/test_helper.clj
@@ -4,6 +4,8 @@
             [clojure.java.io :as io]
             [clojure.test :as t]))
 
+;; Requires X11 or some other graphics environment
+;; hency why cljs-test needs an xvfb-run wrapper
 (defn- display-density []
   (try
     (.. GraphicsEnvironment (getLocalGraphicsEnvironment) (getDefaultScreenDevice) (getScaleFactor))

--- a/test/quil/snippets/test_helper.clj
+++ b/test/quil/snippets/test_helper.clj
@@ -34,15 +34,13 @@
        test-name
        "-difference.png"))
 
-(defn installed? [& cmds]
+(defn installed? [cmd]
   (try
-    (apply sh/sh cmds)
-    true
+    (= 0 (:exit (sh/sh "which" cmd)))
     (catch java.io.IOException _e false)))
 
 ;; imagemagick7 prepends identify, convert, compare with the magick command
-(def magick7-installed?
-  (some? (installed? "magick" "-version")))
+(def magick7-installed? (installed? "magick"))
 
 (defn magick [& args]
   (if magick7-installed?
@@ -105,9 +103,9 @@
     (assert-match-reference! test-name platform actual-file threshold)))
 
 (defn imagemagick-installed [f]
-  (if (or (installed? "magick" "-version")
-          (and (installed? "compare" "-version")
-               (installed? "convert" "-version")
-               (installed? "identify" "-version")))
+  (if (or (installed? "magick")
+          (and (installed? "compare")
+               (installed? "convert")
+               (installed? "identify")))
     (f)
     (throw (ex-info "Imagemagick not detected. Please install it for automated image comparison to work." {}))))


### PR DESCRIPTION
- Updates to use maven hosted Processing 4.4 artifacts
- Install ImageMagick on github actions containers to ensure snapshot testing actually runs
  - Support using ImageMagick 6 or 7 for snapshot testing
- update other build tooling and dependencies
- Use headless browsers where possible for testing

With the update to Processing 4.4, the core libraries are correctly fetching from a maven repo. We still have to fallback to quil copies of `processing-{dxf,pdf,svg}` as those are not yet released to maven as independent artifacts.

 - [ ] Update our versions of dxf,pdf,svg to derive from 4.4 release and deprecate uploading a custom processing core.

Unfortunately, jogl and the rest of the system dependent graphics stack are still in the jogl maven repository, and not in a centrally available one, which was part of the justification for building an uberjar. Unfortunately uberjar packing is still blocking support for quil with clojurescript. 

It might make sense to either deprecate the uberjar entirely and just document adding the jogl repo, or consider releasing two artifacts, one for clojurescript and one bundled with all the graphics libraries.

Separately the test suite is still pretty cranky in github actions. While I have encountered negligable problems on my local ubuntu box, it's pretty frequent that java dumps core while running snapshot tests on github actions for ubuntu. I suspect this may be due to running under `xvfb-run` with a virtual framebuffer instead of an actual graphics stack. OSX and the cljs tests seem pretty reliable.