### PR TITLE
Disable GLWindow destroy in executor during tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,6 +143,8 @@ jobs:
       # verified from a CLJS context.
       - name: Test
         timeout-minutes: 5
+        env:
+          GLWINDOW_SEGV_HACK: 1
         run: |
           ${{ matrix.os == 'ubuntu-latest' && 'xvfb-run' || '' }} clojure -M:dev:kaocha --no-capture-output --reporter doc unit clj-snippets
 

--- a/src/clj/quil/applet.clj
+++ b/src/clj/quil/applet.clj
@@ -39,7 +39,14 @@
       ;; and NPE is thrown when they execute if window is destroyed. It doesn't seem
       ;; to affect anything, but annoying to have NPE in logs. Delaying destroying
       ;; window for 1 sec. Ugly hack, but couldn't think of better way. Suggestions welcome.
-      (.schedule executor #(.destroy native) 1 java.util.concurrent.TimeUnit/SECONDS)
+      ;;
+      ;; Linux is throwing SEGVs in tests trying to operate on surfaces that
+      ;; have already been disposed by the delayed executor's destroy.
+      ;; Unfortunately this is heavily threaded through Java processing code, so
+      ;; for now, in tests, allow GLWindow's to persist until System/exit closes
+      ;; them at the end of tests.
+      (when-not (System/getenv "GLWINDOW_SEGV_HACK")
+        (.schedule executor #(.destroy native) 1 java.util.concurrent.TimeUnit/SECONDS))
 
       processing.awt.PSurfaceAWT$SmoothCanvas
       (-> native .getFrame .dispose)


### PR DESCRIPTION
Tests are rapidly opening and closing applets, and destroying the GLWindow was triggering a race condition trying to modify it after destroying the object. In practice we do want to close the applet after a test, but not at the cost of causing a SEGV trying to operate on a GLWindow after it was destroyed.

We *do* want applets to close on their own in user code however, so hence the environment variable feature flag that should only be set in tests.