### PR TITLE
Add deps.edn prep lib support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,6 @@ In ClojureScript all changes to cljs files (e.g. `dev/sample.cljs` or `src/cljs/
 * Install [clojure-cli](https://clojure.org/guides/install_clojure) and [babashka](https://github.com/babashka/babashka#installation).
 * `clojure -T:build aot` will do an Ahead of Time compilation of a few classes required to interface with Processing.
 
-*Important* because of the dependency on Processing jars which are not hosted in any maven repository, it is not currently possible to use quil as a `:git/sha` coordinate dependency.
-
 Run automated tests locally for clj or cljs with:
 
 * `clojure -Mdev:kaocha unit clj-snippets` for clj tests
@@ -168,6 +166,9 @@ Run automated tests locally for clj or cljs with:
 The coverage from the tests in the leiningen environment are still higher, but are being migrated over to automated tests that can run on Github Actions.
 
 To develop with clj using emacs and the cider repl, use `C-u M-x cider-jack-in-clj`, then select `clojure-cli` and append `:dev` to the list of `-M` aliases. This ensures that "test" is in the classpath along with testing dependencies, so that it's possible to evaluate tests at the repl.
+
+
+See [development](docs/development.md) and [testing](docs/testing.md) for additional documentation on local development.
 
 ## License
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+* Add deps.edn prep lib support [#429](https://github.com/quil/quil/pull/429)
+* Allow mixed type constants for q/begin-shape [#416](https://github.com/quil/quil/pull/416)
+* Ratchet accepted difference threshold for visual tests + improve tests [#428](https://github.com/quil/quil/pull/428)
+* Disable GLWindow destroy in executor during test [#427](https://github.com/quil/quil/pull/427)
+* Fix CLJS Advanced Compilation & Use JAR for releases [#412](https://github.com/quil/quil/pull/412)
+* Upgrade to Processing 4.5.2 [#425](https://github.com/quil/quil/pull/425)
+* Fix SVG render tests fetching GNU Hackert logo [#424](https://github.com/quil/quil/pull/424)
+* Processing 4.4 and test improvements [#421](https://github.com/quil/quil/pull/421)
+* Fix broken link in defsketch docstring [#418](https://github.com/quil/quil/pull/418)
+
 ## 4.3.1563
 __21st January 2024__
 

--- a/deps.edn
+++ b/deps.edn
@@ -18,6 +18,7 @@
 
         ;; clojurescript p5js
         cljsjs/p5 {:mvn/version "1.7.0-0"}}
+ :deps/prep-lib {:alias :build :fn aot :ensure "target/classes"}
  :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.13"}
                           slipset/deps-deploy {:mvn/version "RELEASE"}}
                    :ns-default build}

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,20 @@
+# Development
+
+## Developing a library referencing Quil
+
+To use a local copy of Quil as a dependency for another library, use [git dep](https://clojure.org/reference/deps_edn#deps_git) or a [local root](https://clojure.org/reference/deps_edn#deps_local) instead of a maven jar dependency.
+
+```clojure
+{:deps {quil/quil {:git/url "https://github.com/quil/quil" + ;; + :git/sha or :git/tag
+                   ;; OR :local/root "../path/to/quil"
+                   }}}
+```
+
+However, quil has some code that requires ahead of time (AOT) compilation to interface with Processing. After adding a git or local root dependency for quil, run:
+
+```bash
+clj -X:deps prep
+```
+
+This will force the clojure CLI to AOT compile the interfaces to Processing. See the `deps.edn` documentation on [prep libs](https://clojure.org/guides/deps_and_cli#prep_libs) for more details.
+


### PR DESCRIPTION
Quil uses AOT compiled classes and interfaces to interop with part of Processing. This adds support for referencing quil from a library as a git dep or local/root, so long as `clj -X:deps prep` is run first.

Ie it's now possible to reference quil as a git dep in `deps.edn` like:

```clojure
{:deps {quil/quil {:git/url "https://github.com/quil/quil"}
```

OR as a local dependency:
```clojure
{:deps {quil/quil {:local/root "../path/to/local/quil"}
```

And then run 
```bash
clojure -X:deps prep
```

in the library or application that depends on quil to run the AOT compilation of class files to interface with Processing.

